### PR TITLE
Новый интерфейс modetab

### DIFF
--- a/libs/compiler/analyzer.c
+++ b/libs/compiler/analyzer.c
@@ -29,7 +29,6 @@ analyzer compiler_context_create(universal_io *const io, syntax *const sx)
 
 	context.charnum = 0;
 	context.charnum_before = 0;
-	//context.startmode = 1;
 	context.sopnd = -1;
 	context.curid = 2;
 	context.lg = -1;

--- a/libs/compiler/analyzer.c
+++ b/libs/compiler/analyzer.c
@@ -29,7 +29,7 @@ analyzer compiler_context_create(universal_io *const io, syntax *const sx)
 
 	context.charnum = 0;
 	context.charnum_before = 0;
-	context.startmode = 1;
+	//context.startmode = 1;
 	context.sopnd = -1;
 	context.curid = 2;
 	context.lg = -1;
@@ -112,7 +112,7 @@ void init_modetab(analyzer *context)
 	context->sx->modetab[16] = LVOIDASTER;
 	context->sx->modetab[17] = 1;
 	context->sx->modetab[18] = LVOIDASTER;
-	context->sx->modetab[19] = context->startmode = 14;
+	context->sx->modetab[19] = context->sx->startmode = 14;
 	context->sx->md = 19;
 	context->keywordsnum = 0;
 	context->line = 1;

--- a/libs/compiler/analyzer.h
+++ b/libs/compiler/analyzer.h
@@ -55,7 +55,6 @@ typedef struct analyzer
 	int curchar;
 	int func_def;
 	int hashtab[256];
-	int startmode;
 	int stack[100];
 	int stackop[100];
 	int stackoperands[100];

--- a/libs/compiler/extdecl.c
+++ b/libs/compiler/extdecl.c
@@ -524,7 +524,7 @@ void mustbestring(analyzer *context)
 	}
 	toval(context);
 	context->sopnd--;
-	if (!(is_array(context->sx, context->ansttype) && modetab_get(context->sx, context->ansttype + 1) != LCHAR))
+	if (!(is_array(context->sx, context->ansttype) && modetab_get(context->sx, context->ansttype + 1) == LCHAR))
 	{
 		context_error(context, not_string_in_stanfunc);
 		context->error_flag = 5;

--- a/libs/compiler/extdecl.c
+++ b/libs/compiler/extdecl.c
@@ -37,7 +37,10 @@ void block(analyzer *context, int b);
 
 int newdecl(syntax *const sx, const int type, const int element_type)
 {
-	return mode_add(sx, (int []){type, element_type}, 2);
+	int temp[2];
+	temp[0] = type;
+	temp[1] = element_type;
+	return mode_add(sx, temp, 2);
 }
 
 

--- a/libs/compiler/extdecl.c
+++ b/libs/compiler/extdecl.c
@@ -115,14 +115,14 @@ int check_duplicates(analyzer *context)
 	// проверяет, имеется ли в modetab только что внесенный тип.
 	// если да, то возвращает ссылку на старую запись, иначе - на новую.
 
-	int old = context->sx->modetab[context->startmode];
+	int old = context->sx->modetab[context->sx->startmode];
 
 	while (old)
 	{
-		if (modeeq(context, context->startmode + 1, old + 1))
+		if (modeeq(context, context->sx->startmode + 1, old + 1))
 		{
-			context->sx->md = context->startmode;
-			context->startmode = context->sx->modetab[context->startmode];
+			context->sx->md = context->sx->startmode;
+			context->sx->startmode = context->sx->modetab[context->sx->startmode];
 			return old + 1;
 		}
 		else
@@ -130,13 +130,13 @@ int check_duplicates(analyzer *context)
 			old = context->sx->modetab[old];
 		}
 	}
-	return context->startmode + 1;
+	return context->sx->startmode + 1;
 }
 
 int newdecl(analyzer *context, int type, int elemtype)
 {
-	context->sx->modetab[context->sx->md] = context->startmode;
-	context->startmode = context->sx->md++;
+	context->sx->modetab[context->sx->md] = context->sx->startmode;
+	context->sx->startmode = context->sx->md++;
 	context->sx->modetab[context->sx->md++] = type;
 	context->sx->modetab[context->sx->md++] = elemtype; // ссылка на элемент
 

--- a/libs/compiler/extdecl.c
+++ b/libs/compiler/extdecl.c
@@ -3414,14 +3414,16 @@ int struct_decl_list(analyzer *context)
 
 	loc_modetab[1] = curdispl; // тут длина структуры
 	loc_modetab[2] = field_count * 2;
+	
+	return modetab_add(context->sx, locmd, loc_modetab);
 
-	context->sx->modetab[context->sx->md] = context->startmode;
+	/*context->sx->modetab[context->sx->md] = context->startmode;
 	context->startmode = context->sx->md++;
 	for (i = 0; i < locmd; i++)
 	{
 		context->sx->modetab[context->sx->md++] = loc_modetab[i];
 	}
-	return check_duplicates(context);
+	return check_duplicates(context);*/
 }
 
 int gettype(analyzer *context)
@@ -3903,15 +3905,17 @@ int func_declarator(analyzer *context, int level, int func_d, int firstdecl)
 	}
 	context->func_def = func_d;
 	loc_modetab[2] = numpar;
+	
+	return modetab_add(context->sx, locmd, loc_modetab);
 
-	context->sx->modetab[context->sx->md] = context->startmode;
+	/*context->sx->modetab[context->sx->md] = context->startmode;
 	context->startmode = context->sx->md++;
 	for (i = 0; i < numpar + 3; i++)
 	{
 		context->sx->modetab[context->sx->md++] = loc_modetab[i];
 	}
 
-	return check_duplicates(context);
+	return check_duplicates(context);*/
 }
 
 /** Генерация дерева */

--- a/libs/compiler/extdecl.c
+++ b/libs/compiler/extdecl.c
@@ -3249,7 +3249,6 @@ int idorpnt(analyzer *context, int e, int t)
 int struct_decl_list(analyzer *context)
 {
 	int field_count = 0;
-	int i;
 	int t;
 	int elem_type;
 	int curdispl = 0;
@@ -3658,7 +3657,6 @@ int func_declarator(analyzer *context, int level, int func_d, int firstdecl)
 	int ident = 0; // warning C4701: potentially uninitialized local variable used
 	int maybe_fun = 0; // warning C4701: potentially uninitialized local variable used
 	int repeat = 1;
-	int i;
 	int wastype = 0;
 	int old;
 

--- a/libs/compiler/extdecl.c
+++ b/libs/compiler/extdecl.c
@@ -168,6 +168,11 @@ int is_array(syntax *const sx, const int t)
 	return t > 0 && modetab_get(sx, t) == MARRAY;
 }
 
+int is_string(syntax *const sx, const int t)
+{
+	return is_array(sx, t) && modetab_get(sx, t + 1) == LCHAR;
+}
+
 int is_pointer(syntax *const sx, const int t)
 {
 	return t > 0 && modetab_get(sx, t) == MPOINT;
@@ -524,7 +529,7 @@ void mustbestring(analyzer *context)
 	}
 	toval(context);
 	context->sopnd--;
-	if (!(is_array(context->sx, context->ansttype) && modetab_get(context->sx, context->ansttype + 1) == LCHAR))
+	if (!(is_string(context->sx, context->ansttype)))
 	{
 		context_error(context, not_string_in_stanfunc);
 		context->error_flag = 5;
@@ -542,9 +547,7 @@ void mustbepointstring(analyzer *context)
 	}
 	toval(context);
 	context->sopnd--;
-	if (!(context->ansttype > 0 && context->sx->modetab[context->ansttype] == MPOINT &&
-		  is_array(context->sx, context->sx->modetab[context->ansttype + 1]) &&
-		  context->sx->modetab[context->sx->modetab[context->ansttype + 1] + 1] == LCHAR))
+	if (!(is_pointer(context->sx, context->ansttype) && is_string(context->sx, context->ansttype + 1)))
 	{
 		context_error(context, not_point_string_in_stanfunc);
 		context->error_flag = 5;

--- a/libs/compiler/extdecl.c
+++ b/libs/compiler/extdecl.c
@@ -547,7 +547,8 @@ void mustbepointstring(analyzer *context)
 	}
 	toval(context);
 	context->sopnd--;
-	if (!(is_pointer(context->sx, context->ansttype) && is_string(context->sx, context->ansttype + 1)))
+	if (!(is_pointer(context->sx, context->ansttype) &&
+		  is_string(context->sx, modetab_get(context->sx, context->ansttype + 1))))
 	{
 		context_error(context, not_point_string_in_stanfunc);
 		context->error_flag = 5;

--- a/libs/compiler/syntax.c
+++ b/libs/compiler/syntax.c
@@ -107,3 +107,14 @@ int modetab_add(syntax *const sx, const int size, const int new_record[])
 	}
 	return check_mode_duplicates(sx);
 }
+
+
+int newdecl(syntax *const sx, const int type, const int elemtype)
+{
+	sx->modetab[sx->md] = sx->startmode;
+	sx->startmode = sx->md++;
+	sx->modetab[sx->md++] = type;
+	sx->modetab[sx->md++] = elemtype; // ссылка на элемент
+	
+	return check_mode_duplicates(sx);
+}

--- a/libs/compiler/syntax.c
+++ b/libs/compiler/syntax.c
@@ -108,6 +108,11 @@ int modetab_add(syntax *const sx, const int size, const int new_record[])
 	return check_mode_duplicates(sx);
 }
 
+int modetab_get(syntax *const sx, const int index)
+{
+	return sx->modetab[index];
+}
+
 
 int newdecl(syntax *const sx, const int type, const int elemtype)
 {

--- a/libs/compiler/syntax.c
+++ b/libs/compiler/syntax.c
@@ -28,6 +28,7 @@ syntax sx_create()
 	sx.funcnum = 2;
 	sx.id = 2;
 	sx.md = 1;
+	sx.startmode = 1;
 	sx.tc = 0;
 	sx.rp = 1;
 	sx.repr = 0;
@@ -38,4 +39,71 @@ syntax sx_create()
 	sx.anstdispl = 0;
 
 	return sx;
+}
+
+
+int equal_modes(syntax *const sx, int first_mode, int second_mode)
+{
+	int record_length;
+	int i;
+	int flag = 1;
+	int mode;
+	
+	if (sx->modetab[first_mode] != sx->modetab[second_mode])
+	{
+		return 0;
+	}
+	
+	mode = sx->modetab[first_mode];
+	// Определяем, сколько полей надо сравнивать для различных типов записей
+	if (mode == MSTRUCT || mode == MFUNCTION)
+		record_length = 2 + sx->modetab[first_mode + 2];
+	else
+		record_length = 1;
+	
+	for (i = 1; i <= record_length && flag; i++)
+	{
+		if (sx->modetab[first_mode + i] != sx->modetab[second_mode + i])
+		{
+			return 0;
+		}
+	}
+	
+	return 1;
+}
+
+
+int check_mode_duplicates(syntax *const sx)
+{
+	// Проверяет, имеется ли в modetab только что внесенный тип
+	// Если да, то возвращает ссылку на старую запись, иначе - на новую
+	
+	int old = sx->modetab[sx->startmode];
+	
+	while (old)
+	{
+		if (equal_modes(sx, sx->startmode + 1, old + 1))
+		{
+			sx->md = sx->startmode;
+			sx->startmode = sx->modetab[sx->startmode];
+			return old + 1;
+		}
+		else
+		{
+			old = sx->modetab[old];
+		}
+	}
+	return sx->startmode + 1;
+}
+
+
+int modetab_add(syntax *const sx, const int size, const int new_record[])
+{
+	sx->modetab[sx->md] = sx->startmode;
+	sx->startmode = sx->md++;
+	for (int i = 0; i < size; i++)
+	{
+		sx->modetab[sx->md++] = new_record[i];
+	}
+	return check_mode_duplicates(sx);
 }

--- a/libs/compiler/syntax.h
+++ b/libs/compiler/syntax.h
@@ -66,6 +66,8 @@ typedef struct syntax
 syntax sx_create();
 
 
+int check_mode_duplicates(syntax *sx);
+
 /**
  *	Add new record to modetab
  *
@@ -75,6 +77,16 @@ syntax sx_create();
  *	@return	Pointer to new record
  */
 int modetab_add(syntax *const sx, const int size, const int new_record[]);
+
+/**
+ *	Add new record of array or pointer to modetab
+ *
+ *	@param	sx	Syntax structure
+ *	@param	type	Type of record: @c MARRAY or @c MPOINT
+ *	@param	elemtype	Type of element
+ *	@return	Pointer to new record
+ */
+int newdecl(syntax *const sx, const int type, const int elemtype);
 
 #ifdef __cplusplus
 } /* extern "C" */

--- a/libs/compiler/syntax.h
+++ b/libs/compiler/syntax.h
@@ -17,6 +17,7 @@
 #pragma once
 
 #include "defs.h"
+#include <stddef.h>
 
 
 #ifdef __cplusplus
@@ -41,8 +42,8 @@ typedef struct syntax
 	int id;						/**< Number of identifiers */
 
 	int modetab[MAXMODETAB];	/**< Modes table */
-	int startmode;				/**< Start of last record in modetab */
 	int md;						/**< Number of modes */
+	int startmode;				/**< Start of last record in modetab */
 	
 	int tree[MAXTREESIZE];		/**< Tree */
 	int tc;						/**< Tree counter */
@@ -69,30 +70,21 @@ syntax sx_create();
  *	Add new record to modetab
  *
  *	@param	sx	Syntax structure
+ *	@param	record	Pointer to the new record
  *	@param	size	Size of the new record
- *	@param	new_record	The new record itself
- *	@return	Pointer to new record
+ *
+ *	@return	Index of the new record from modetab
  */
-int modetab_add(syntax *const sx, const int size, const int new_record[]);
+size_t mode_add(syntax *const sx, const int *const record, const size_t size);
 
 /**
  *	Get an item from modetab by index
  *
  *	@param	sx	Syntax structure
  *	@param	index	Index of record
- *	@return	Item by index in modetab
+ *	@return	Item by index from modetab
  */
-int modetab_get(syntax *const sx, const int index);
-
-/**
- *	Add new record of array or pointer to modetab
- *
- *	@param	sx	Syntax structure
- *	@param	type	Type of record: @c MARRAY or @c MPOINT
- *	@param	elemtype	Type of element
- *	@return	Pointer to new record
- */
-int newdecl(syntax *const sx, const int type, const int elemtype);
+int mode_get(syntax *const sx, const size_t index);
 
 #ifdef __cplusplus
 } /* extern "C" */

--- a/libs/compiler/syntax.h
+++ b/libs/compiler/syntax.h
@@ -65,9 +65,6 @@ typedef struct syntax
  */
 syntax sx_create();
 
-
-int check_mode_duplicates(syntax *sx);
-
 /**
  *	Add new record to modetab
  *

--- a/libs/compiler/syntax.h
+++ b/libs/compiler/syntax.h
@@ -28,32 +28,33 @@ typedef struct syntax
 {
 	// mem, pc & iniprocs - usage here only for codes printing
 
-	int mem[MAXMEMSIZE];		/** Memory */
-	int pc;						/** Program counter */
+	int mem[MAXMEMSIZE];		/**< Memory */
+	int pc;						/**< Program counter */
 
-	int iniprocs[INIPROSIZE];	/** Init processes */
-	int procd;					/** Process management daemon */
+	int iniprocs[INIPROSIZE];	/**< Init processes */
+	int procd;					/**< Process management daemon */
 
-	int functions[FUNCSIZE];	/** Functions table */
-	int funcnum;				/** Number of functions */
+	int functions[FUNCSIZE];	/**< Functions table */
+	int funcnum;				/**< Number of functions */
 
-	int identab[MAXIDENTAB];	/** Identifiers table */
-	int id;						/** Number of identifiers */
+	int identab[MAXIDENTAB];	/**< Identifiers table */
+	int id;						/**< Number of identifiers */
 
-	int modetab[MAXMODETAB];	/** Modes table */
-	int md;						/** Number of modes */
+	int modetab[MAXMODETAB];	/**< Modes table */
+	int startmode;				/**< Start of last record in modetab */
+	int md;						/**< Number of modes */
 	
-	int tree[MAXTREESIZE];		/** Tree */
-	int tc;						/** Tree counter */
+	int tree[MAXTREESIZE];		/**< Tree */
+	int tc;						/**< Tree counter */
 
-	int reprtab[MAXREPRTAB];	/** Representations table */
-	int rp;						/** Representations size */
-	int repr;					/** Representations position */
+	int reprtab[MAXREPRTAB];	/**< Representations table */
+	int rp;						/**< Representations size */
+	int repr;					/**< Representations position */
 
-	int maxdisplg;				/** Max displacement */
-	int wasmain;				/** Main function flag */
+	int maxdisplg;				/**< Max displacement */
+	int wasmain;				/**< Main function flag */
 
-	int anstdispl;				/** Stack displacement */
+	int anstdispl;				/**< Stack displacement */
 } syntax;
 
 
@@ -63,6 +64,17 @@ typedef struct syntax
  *	@return	Syntax structure
  */
 syntax sx_create();
+
+
+/**
+ *	Add new record to modetab
+ *
+ *	@param	sx	Syntax structure
+ *	@param	size	Size of the new record
+ *	@param	new_record	The new record itself
+ *	@return	Pointer to new record
+ */
+int modetab_add(syntax *const sx, const int size, const int new_record[]);
 
 #ifdef __cplusplus
 } /* extern "C" */

--- a/libs/compiler/syntax.h
+++ b/libs/compiler/syntax.h
@@ -76,6 +76,15 @@ syntax sx_create();
 int modetab_add(syntax *const sx, const int size, const int new_record[]);
 
 /**
+ *	Get an item from modetab by index
+ *
+ *	@param	sx	Syntax structure
+ *	@param	index	Index of record
+ *	@return	Item by index in modetab
+ */
+int modetab_get(syntax *const sx, const int index);
+
+/**
  *	Add new record of array or pointer to modetab
  *
  *	@param	sx	Syntax structure

--- a/src/main.c
+++ b/src/main.c
@@ -22,7 +22,7 @@
 #include "workspace.h"
 
 
-const char *name = "../tests/executable/floatsign.c";
+const char *name = "../tests/sleep/threads/russian.c";
 // "../tests/mips/0test.c";
 
 


### PR DESCRIPTION
- добавлены modetab_add и modetab_get
- функции для поддержки modetab перенесены в syntax, теперь они вызываются только оттуда
- startmode перенесен в syntax, он там нужнее
- extdecl больше не обращется напрямую к modetab, используются только modetab_add, modetab_get, newdecl
- newdecl оставлена только для удобства: для нее не нужно каждый раз создавать массив, она принимает только записи длины 2