### PR TITLE
Virtual machine codegen (pre-release)

### DIFF
--- a/libs/compiler/codegen.c
+++ b/libs/compiler/codegen.c
@@ -335,21 +335,20 @@ static void expression(syntax *const sx, node *const nd, int mode)
 
 static void structure(syntax *const sx, node *const nd)
 {
-	node cur = node_get_next(nd);
-	if (node_get_type(&cur) == TStructinit)
+	if (node_get_type(nd) == TStructinit)
 	{
-		const int N = node_get_arg(&cur, 0);
+		const int N = node_get_arg(nd, 0);
+		node_set_next(nd);
+
 		for (int i = 0; i < N; i++)
 		{
-			structure(sx, &cur);
+			structure(sx, nd);
+			node_set_next(nd); // TExprend
 		}
-
-		node_set_next(&cur); // TExprend
-		node_copy(nd, &cur);
 	}
 	else
 	{
-		expression(sx, nd, 0);
+		expression(sx, nd, -1);
 	}
 }
 
@@ -389,6 +388,7 @@ static void identifier(syntax *const sx, node *const nd)
 		{
 			if (type > 0 && mode_get(sx, type) == MSTRUCT)
 			{
+				node_set_next(nd);
 				structure(sx, nd);
 
 				tocode(sx, COPY0STASS);

--- a/libs/compiler/codegen.c
+++ b/libs/compiler/codegen.c
@@ -386,11 +386,8 @@ void Stmt_gen(syntax *const sx, ad *const context)
 			break;
 		}
 		case TBegin:
-		{
-			tree_next_node(sx); // TBegin
 			compstmt_gen(sx, context);
 			break;
-		}
 		case TIf:
 		{
 			int ref_else = node_get_arg(tree_get_node(sx), 0);
@@ -771,38 +768,32 @@ void Declid_gen(syntax *const sx)
 
 void compstmt_gen(syntax *const sx, ad *const context)
 {
+	tree_next_node(sx); // TBegin
+
 	while (node_get_type(tree_get_node(sx)) != TEnd)
 	{
 		switch (node_get_type(tree_get_node(sx)))
 		{
 			case TDeclarr:
 			{
-				int N = node_get_arg(tree_get_node(sx), 0);
-
-				tree_next_node(sx);
-
+				const int N = node_get_arg(tree_get_node(sx), 0);
 				for (int i = 0; i < N; i++)
 				{
+					tree_next_node(sx);
 					Expr_gen(sx, 0);
-					tree_next_node(sx); // TExprend
 				}
 				break;
 			}
 			case TDeclid:
-			{
 				Declid_gen(sx);
-				tree_next_node(sx); // TExpend
 				break;
-			}
 			default:
-			{
 				Stmt_gen(sx, context);
-				tree_next_node(sx);
 				break;
-			}
 		}
+
+		tree_next_node(sx);
 	}
-	//tree_next_node(sx); // TEnd
 }
 
 /** Генерация кодов */
@@ -831,7 +822,6 @@ int codegen(syntax *const sx)
 				size_t old_pc = mem_get_size(sx);
 				mem_increase(sx, 1);
 				tree_next_node(sx);
-				tree_next_node(sx); // TBegin
 				compstmt_gen(sx, &context);
 				mem_set(sx, old_pc, (int)mem_get_size(sx));
 				break;

--- a/libs/compiler/codegen.c
+++ b/libs/compiler/codegen.c
@@ -399,6 +399,7 @@ void Stmt_gen(syntax *const sx, ad *const context)
 		{
 			tree_next_node(sx);
 			compstmt_gen(sx, context);
+			tree_next_node(sx); // TEnd
 			break;
 		}
 		case TIf:
@@ -806,7 +807,7 @@ void compstmt_gen(syntax *const sx, ad *const context)
 			}
 		}
 	}
-	tree_next_node(sx); // TEnd
+	//tree_next_node(sx); // TEnd
 }
 
 /** Генерация кодов */
@@ -841,6 +842,7 @@ int codegen(syntax *const sx)
 				tree_next_node(sx);
 				tree_next_node(sx); // TBegin
 				compstmt_gen(sx, &context);
+				tree_next_node(sx); // TEnd
 				mem_set(sx, old_pc, (int)mem_get_size(sx));
 				break;
 			}

--- a/libs/compiler/codegen.c
+++ b/libs/compiler/codegen.c
@@ -362,29 +362,19 @@ void Stmt_gen(syntax *const sx, ad *const context)
 	switch (node_get_type(tree_get_node(sx)))
 	{
 		case NOP:
-		{
-			tree_next_node(sx);
 			break;
-		}
 		case CREATEDIRECTC:
-		{
 			tocode(sx, CREATEDIRECTC);
-			tree_next_node(sx);
 			break;
-		}
 		case EXITDIRECTC:
 		case EXITC:
-		{
 			tocode(sx, EXITC);
-			tree_next_node(sx);
 			break;
-		}
 		case TStructbeg:
 		{
 			tocode(sx, B);
 			tocode(sx, 0);
 			proc_set(sx, node_get_arg(tree_get_node(sx), 0), (int)mem_get_size(sx));
-			tree_next_node(sx);
 			break;
 		}
 		case TStructend:
@@ -392,15 +382,13 @@ void Stmt_gen(syntax *const sx, ad *const context)
 			int numproc = node_get_arg(tree_get_node(sx), 0);
 
 			tocode(sx, STOP);
-			mem_set(sx, proc_get(sx, numproc) - 1, (int)mem_get_size(sx));	
-			tree_next_node(sx);
+			mem_set(sx, proc_get(sx, numproc) - 1, (int)mem_get_size(sx));
 			break;
 		}
 		case TBegin:
 		{
 			tree_next_node(sx); // TBegin
 			compstmt_gen(sx, context);
-			tree_next_node(sx); // TEnd
 			break;
 		}
 		case TIf:
@@ -416,6 +404,7 @@ void Stmt_gen(syntax *const sx, ad *const context)
 			Stmt_gen(sx, context);
 			if (ref_else)
 			{
+				tree_next_node(sx);
 				mem_set(sx, ad, (int)mem_get_size(sx) + 2);
 				tocode(sx, B);
 				ad = mem_get_size(sx);
@@ -460,8 +449,10 @@ void Stmt_gen(syntax *const sx, ad *const context)
 
 			Stmt_gen(sx, context);
 			adcontend(sx, context);
+
+			tree_next_node(sx);
 			Expr_gen(sx, 0);
-			tree_next_node(sx); // TExprend
+
 			tocode(sx, BNE0);
 			tocode(sx, (int)ad);
 			adbreakend(sx, context);
@@ -519,7 +510,6 @@ void Stmt_gen(syntax *const sx, ad *const context)
 				node incr = node_get_child(tfor, child_stmt - 1);
 				tree_set_node(sx, &incr);
 				Expr_gen(sx, 0); // incr
-				tree_next_node(sx); // TExprend
 			}
 
 			*tfor = temp;
@@ -550,8 +540,6 @@ void Stmt_gen(syntax *const sx, ad *const context)
 				tocode(sx, id1 < 0 ? 0 : a);	// первый раз встретился переход на еще
 												// не описанную метку или нет
 			}
-
-			tree_next_node(sx);
 			break;
 		}
 		case TLabel:
@@ -569,7 +557,6 @@ void Stmt_gen(syntax *const sx, ad *const context)
 				}
 			}
 			ident_set_displ(sx, id, (int)mem_get_size(sx));
-			tree_next_node(sx);
 			break;
 		}
 		case TSwitch:
@@ -628,8 +615,6 @@ void Stmt_gen(syntax *const sx, ad *const context)
 			tocode(sx, B);
 			mem_add(sx, (int)context->adbreak);
 			context->adbreak = mem_get_size(sx) - 1;
-
-			tree_next_node(sx);
 			break;
 		}
 		case TContinue:
@@ -637,22 +622,20 @@ void Stmt_gen(syntax *const sx, ad *const context)
 			tocode(sx, B);
 			mem_add(sx, (int)context->adcont);
 			context->adcont = mem_get_size(sx) - 1;
-			tree_next_node(sx);
 			break;
 		}
 		case TReturnvoid:
 		{
 			tocode(sx, RETURNVOID);
-			tree_next_node(sx);
 			break;
 		}
 		case TReturnval:
 		{
 			int d = node_get_arg(tree_get_node(sx), 0);
-			tree_next_node(sx);
 
+			tree_next_node(sx);
 			Expr_gen(sx, 0);
-			tree_next_node(sx); // TExprend
+
 			tocode(sx, RETURNVAL);
 			tocode(sx, d);
 			break;
@@ -661,22 +644,18 @@ void Stmt_gen(syntax *const sx, ad *const context)
 		{
 			tocode(sx, PRINTID);
 			tocode(sx, node_get_arg(tree_get_node(sx), 0)); // ссылка в identtab
-			tree_next_node(sx);
 			break;
 		}
 		case TPrintf:
 		{
 			tocode(sx, PRINTF);
-			tocode(sx, node_get_arg(tree_get_node(sx), 0)); // общий размер того,
-														   // что надо вывести
-			tree_next_node(sx);
+			tocode(sx, node_get_arg(tree_get_node(sx), 0)); // общий размер того, что надо вывести
 			break;
 		}
 		case TGetid:
 		{
 			tocode(sx, GETID);
 			tocode(sx, node_get_arg(tree_get_node(sx), 0)); // ссылка в identtab
-			tree_next_node(sx);
 			break;
 		}
 		case SETMOTOR:
@@ -684,15 +663,15 @@ void Stmt_gen(syntax *const sx, ad *const context)
 			tree_next_node(sx);
 			Expr_gen(sx, 0);
 			tree_next_node(sx); // TExprend
+
 			Expr_gen(sx, 0);
-			tree_next_node(sx); // TExprend
+
 			tocode(sx, SETMOTORC);
 			break;
 		}
 		default:
 		{
 			Expr_gen(sx, 0);
-			tree_next_node(sx); // TExprend
 			break;
 		}
 	}
@@ -818,6 +797,7 @@ void compstmt_gen(syntax *const sx, ad *const context)
 			default:
 			{
 				Stmt_gen(sx, context);
+				tree_next_node(sx);
 				break;
 			}
 		}

--- a/libs/compiler/codegen.c
+++ b/libs/compiler/codegen.c
@@ -699,26 +699,20 @@ void Stmt_gen(syntax *const sx, ad *const context)
 
 void Struct_init_gen(syntax *const sx)
 {
-	int i;
-	int n;
-
-
 	if (node_get_type(tree_get_node(sx)) == TStructinit)
 	{
-		n = node_get_arg(tree_get_node(sx), 0);
-
+		const int n = node_get_arg(tree_get_node(sx), 0);
 		tree_next_node(sx);
 
-		for (i = 0; i < n; i++)
+		for (int i = 0; i < n; i++)
 		{
 			Struct_init_gen(sx);
+			tree_next_node(sx); // TExprend
 		}
-		tree_next_node(sx); // TExprend
 	}
 	else
 	{
 		Expr_gen(sx, 0);
-		tree_next_node(sx); // TExprend
 	}
 }
 
@@ -753,6 +747,7 @@ void Declid_gen(syntax *const sx)
 			if (telem > 0 && mode_get(sx, telem) == MSTRUCT)
 			{
 				Struct_init_gen(sx);
+				tree_next_node(sx); // TExprend
 				tocode(sx, COPY0STASS);
 				tocode(sx, olddispl);
 				tocode(sx, all); // общее кол-во слов

--- a/libs/compiler/codegen.c
+++ b/libs/compiler/codegen.c
@@ -220,6 +220,7 @@ int Expr_gen(syntax *const sx, int incond)
 			case TDeclid:
 			{
 				Declid_gen(sx);
+				tree_next_node(sx); // TExpend
 				break;
 			}
 			case TBeginit:
@@ -732,7 +733,6 @@ void Declid_gen(syntax *const sx)
 	// all == 0 нет инициализатора,
 	// all == 1 есть инициализатор
 	// all == 2 есть инициализатор только из строк
-	tree_next_node(sx);
 
 	if (N == 0) // обычная переменная int a; или struct point p;
 	{
@@ -746,16 +746,18 @@ void Declid_gen(syntax *const sx)
 		{
 			if (telem > 0 && mode_get(sx, telem) == MSTRUCT)
 			{
+				tree_next_node(sx);
 				Struct_init_gen(sx);
-				tree_next_node(sx); // TExprend
+
 				tocode(sx, COPY0STASS);
 				tocode(sx, olddispl);
 				tocode(sx, all); // общее кол-во слов
 			}
 			else
 			{
+				tree_next_node(sx);
 				Expr_gen(sx, 0);
-				tree_next_node(sx); // TExprend
+
 				tocode(sx, telem == LFLOAT ? ASSRV : ASSV);
 				tocode(sx, olddispl);
 			}
@@ -775,8 +777,9 @@ void Declid_gen(syntax *const sx)
 
 		if (all) // all == 1, если есть инициализация массива
 		{
+			tree_next_node(sx);
 			Expr_gen(sx, 0);
-			tree_next_node(sx); // TExprend
+
 			tocode(sx, ARRINIT); // ARRINIT N d all displ usual
 			tocode(sx, abs(N));
 			tocode(sx, element_len);
@@ -809,6 +812,7 @@ void compstmt_gen(syntax *const sx, ad *const context)
 			case TDeclid:
 			{
 				Declid_gen(sx);
+				tree_next_node(sx); // TExpend
 				break;
 			}
 			default:
@@ -873,6 +877,7 @@ int codegen(syntax *const sx)
 			case TDeclid:
 			{
 				Declid_gen(sx);
+				tree_next_node(sx); // TExpend
 				break;
 			}
 			case NOP:

--- a/libs/compiler/codegen.c
+++ b/libs/compiler/codegen.c
@@ -476,6 +476,7 @@ static void statement(syntax *const sx, address *const context)
 			break;
 		case CREATEDIRECTC:
 			tocode(sx, CREATEDIRECTC);
+			sx->max_threads++;
 			break;
 		case EXITDIRECTC:
 		case EXITC:
@@ -835,7 +836,7 @@ void output_export(universal_io *const io, const syntax *const sx)
 	uni_printf(io, "#!/usr/bin/ruc-vm\n");
 
 	uni_printf(io, "%zi %zi %zi %zi %zi %i %zi\n", mem_size(sx), sx->funcnum, sx->id,
-				   sx->rp, sx->md, sx->maxdisplg, sx->ref_main);
+				   sx->rp, sx->md, sx->maxdisplg, sx->max_threads);
 
 	for (size_t i = 0; i < mem_size(sx); i++)
 	{

--- a/libs/compiler/codegen.c
+++ b/libs/compiler/codegen.c
@@ -332,20 +332,21 @@ static void expression(syntax *const sx, node *const nd, int mode)
 
 static void structure(syntax *const sx, node *const nd)
 {
-	if (node_get_type(nd) == TStructinit)
+	node cur = node_get_next(nd);
+	if (node_get_type(&cur) == TStructinit)
 	{
-		const int N = node_get_arg(nd, 0);
-		node_set_next(nd);
-
+		const int N = node_get_arg(&cur, 0);
 		for (int i = 0; i < N; i++)
 		{
-			structure(sx, nd);
-			node_set_next(nd); // TExprend
+			structure(sx, &cur);
 		}
+
+		node_set_next(&cur); // TExprend
+		node_copy(nd, &cur);
 	}
 	else
 	{
-		expression(sx, nd, -1);
+		expression(sx, nd, 0);
 	}
 }
 
@@ -385,7 +386,6 @@ static void identifier(syntax *const sx, node *const nd)
 		{
 			if (type > 0 && mode_get(sx, type) == MSTRUCT)
 			{
-				node_set_next(nd);
 				structure(sx, nd);
 
 				tocode(sx, COPY0STASS);
@@ -599,8 +599,7 @@ static void statement(syntax *const sx, node *const nd, address *const context)
 			{
 				expression(sx, &incr, 0); // increment
 			}
-
-			*nd = stmt;
+			node_copy(nd, &stmt);
 
 			tocode(sx, B);
 			tocode(sx, (int)initad);

--- a/libs/compiler/codegen.c
+++ b/libs/compiler/codegen.c
@@ -808,20 +808,16 @@ void compstmt_gen(syntax *const sx, ad *const context)
 /** Генерация кодов */
 int codegen(syntax *const sx)
 {
-	int is_end = 0;
 	node root = node_get_root(sx);
 	tree_set_node(sx, &root);
 
 	ad context;
 
-	tree_next_node(sx);
-
-	while (!is_end)
+	while (tree_next_node(sx) == 0)
 	{
 		switch (node_get_type(tree_get_node(sx)))
 		{
 			case TEnd:
-				is_end = tree_next_node(sx);
 				break;
 			case TFuncdef:
 			{
@@ -837,40 +833,29 @@ int codegen(syntax *const sx)
 				tree_next_node(sx);
 				tree_next_node(sx); // TBegin
 				compstmt_gen(sx, &context);
-				tree_next_node(sx); // TEnd
 				mem_set(sx, old_pc, (int)mem_get_size(sx));
 				break;
 			}
 			case TDeclarr:
 			{
 				int N = node_get_arg(tree_get_node(sx), 0);
-
-				tree_next_node(sx);
-
 				for (int i = 0; i < N; i++)
 				{
+					tree_next_node(sx);
 					Expr_gen(sx, 0);
-					tree_next_node(sx); // TExprend
 				}
 				break;
 			}
 			case TDeclid:
-			{
 				Declid_gen(sx);
-				tree_next_node(sx); // TExpend
 				break;
-			}
 			case NOP:
-			{
-				tree_next_node(sx);
 				break;
-			}
 			case TStructbeg:
 			{
 				tocode(sx, B);
 				tocode(sx, 0);
 				proc_set(sx, node_get_arg(tree_get_node(sx), 0), (int)mem_get_size(sx));
-				tree_next_node(sx);
 				break;
 			}
 			case TStructend:
@@ -879,7 +864,6 @@ int codegen(syntax *const sx)
 
 				tocode(sx, STOP);
 				mem_set(sx, proc_get(sx, numproc) - 1, (int)mem_get_size(sx));
-				tree_next_node(sx);
 				break;
 			}
 			default:
@@ -890,6 +874,7 @@ int codegen(syntax *const sx)
 			}
 		}
 	}
+
 	tocode(sx, CALL1);
 	tocode(sx, CALL2);
 	tocode(sx, ident_get_displ(sx, sx->main_ref));

--- a/libs/compiler/codegen.c
+++ b/libs/compiler/codegen.c
@@ -129,11 +129,10 @@ void finalop(syntax *const sx)
 
 int Expr_gen(syntax *const sx, int incond)
 {
-	int flagprim = 1;
 	int wasstring = 0;
 	int op;
 
-	while (flagprim)
+	while (node_get_type(tree_get_node(sx)) != TExprend)
 	{
 		switch (op = node_get_type(tree_get_node(sx)))
 		{
@@ -347,12 +346,8 @@ int Expr_gen(syntax *const sx, int incond)
 
 			finalop(sx);
 		}
-		if (node_get_type(tree_get_node(sx)) == TExprend)
-		{		
-			flagprim = 0;
-			tree_next_node(sx);
-		}
 	}
+	tree_next_node(sx);
 	return wasstring;
 }
 

--- a/libs/compiler/codegen.c
+++ b/libs/compiler/codegen.c
@@ -64,14 +64,6 @@ static void addr_end_break(syntax *const sx, address *const context)
 }
 
 
-static void tocode(syntax *const sx, int c)
-{
-	// printf("tocode tc=%zi pc=%zi) %i\n", sx->tc,
-	// mem_size(sx), c);
-	mem_add(sx, c);
-}
-
-
 static void final_operation(syntax *const sx, node *const nd)
 {
 	int op = node_get_type(nd);
@@ -81,45 +73,45 @@ static void final_operation(syntax *const sx, node *const nd)
 		{
 			if (op == ADLOGOR)
 			{
-				tocode(sx, _DOUBLE);
-				tocode(sx, BNE0);
+				mem_add(sx, _DOUBLE);
+				mem_add(sx, BNE0);
 				stack_push(sx, (int)mem_size(sx));
 				mem_increase(sx, 1);
 			}
 			else if (op == ADLOGAND)
 			{
-				tocode(sx, _DOUBLE);
-				tocode(sx, BE0);
+				mem_add(sx, _DOUBLE);
+				mem_add(sx, BE0);
 				stack_push(sx, (int)mem_size(sx));
 				mem_increase(sx, 1);
 			}
 			else
 			{
-				tocode(sx, op);
+				mem_add(sx, op);
 				if (op == LOGOR || op == LOGAND)
 				{
 					mem_set(sx, stack_pop(sx), (int)mem_size(sx));
 				}
 				else if (op == COPY00 || op == COPYST)
 				{
-					tocode(sx, node_get_arg(nd, 0)); // d1
-					tocode(sx, node_get_arg(nd, 1)); // d2
-					tocode(sx, node_get_arg(nd, 2)); // длина
+					mem_add(sx, node_get_arg(nd, 0)); // d1
+					mem_add(sx, node_get_arg(nd, 1)); // d2
+					mem_add(sx, node_get_arg(nd, 2)); // длина
 				}
 				else if (op == COPY01 || op == COPY10 || op == COPY0ST || op == COPY0STASS)
 				{
-					tocode(sx, node_get_arg(nd, 0)); // d1
-					tocode(sx, node_get_arg(nd, 1)); // длина
+					mem_add(sx, node_get_arg(nd, 0)); // d1
+					mem_add(sx, node_get_arg(nd, 1)); // длина
 				}
 				else if (op == COPY11 || op == COPY1ST || op == COPY1STASS)
 				{
-					tocode(sx, node_get_arg(nd, 0)); // длина
+					mem_add(sx, node_get_arg(nd, 0)); // длина
 				}
 				else if ((op >= REMASS && op <= DIVASS) || (op >= REMASSV && op <= DIVASSV)
 					|| (op >= ASSR && op <= DIVASSR) || (op >= ASSRV && op <= DIVASSRV) || (op >= POSTINC && op <= DEC)
 					|| (op >= POSTINCV && op <= DECV) || (op >= POSTINCR && op <= DECR) || (op >= POSTINCRV && op <= DECRV))
 				{
-					tocode(sx,node_get_arg(nd, 0));
+					mem_add(sx,node_get_arg(nd, 0));
 				}
 			}
 		}
@@ -155,48 +147,48 @@ static void expression(syntax *const sx, node *const nd, int mode)
 				break;
 			case TIdenttoaddr:
 			{
-				tocode(sx, LA);
-				tocode(sx, node_get_arg(nd, 0));
+				mem_add(sx, LA);
+				mem_add(sx, node_get_arg(nd, 0));
 			}
 			break;
 			case TIdenttoval:
 			{
-				tocode(sx, LOAD);
-				tocode(sx, node_get_arg(nd, 0));
+				mem_add(sx, LOAD);
+				mem_add(sx, node_get_arg(nd, 0));
 			}
 			break;
 			case TIdenttovald:
 			{
-				tocode(sx, LOADD);
-				tocode(sx, node_get_arg(nd, 0));
+				mem_add(sx, LOADD);
+				mem_add(sx, node_get_arg(nd, 0));
 			}
 			break;
 			case TAddrtoval:
-				tocode(sx, LAT);
+				mem_add(sx, LAT);
 				break;
 			case TAddrtovald:
-				tocode(sx, LATD);
+				mem_add(sx, LATD);
 				break;
 			case TConst:
 			{
-				tocode(sx, LI);
-				tocode(sx, node_get_arg(nd, 0));
+				mem_add(sx, LI);
+				mem_add(sx, node_get_arg(nd, 0));
 			}
 			break;
 			case TConstd:
 			{
-				tocode(sx, LID);
-				tocode(sx, node_get_arg(nd, 0));
-				tocode(sx, node_get_arg(nd, 1));
+				mem_add(sx, LID);
+				mem_add(sx, node_get_arg(nd, 0));
+				mem_add(sx, node_get_arg(nd, 1));
 			}
 			break;
 			case TString:
 			case TStringd:
 			{
-				tocode(sx, LI);
+				mem_add(sx, LI);
 				const size_t reserved = mem_size(sx) + 4;
-				tocode(sx, (int)reserved);
-				tocode(sx, B);
+				mem_add(sx, (int)reserved);
+				mem_add(sx, B);
 				mem_increase(sx, 2);
 
 				const int N = node_get_arg(nd, 0);
@@ -204,12 +196,12 @@ static void expression(syntax *const sx, node *const nd, int mode)
 				{
 					if (operation == TString)
 					{
-						tocode(sx, node_get_arg(nd, i + 1));
+						mem_add(sx, node_get_arg(nd, i + 1));
 					}
 					else
 					{
-						tocode(sx, node_get_arg(nd, 2 * i + 1));
-						tocode(sx, node_get_arg(nd, 2 * i + 2));
+						mem_add(sx, node_get_arg(nd, 2 * i + 1));
+						mem_add(sx, node_get_arg(nd, 2 * i + 2));
 					}
 				}
 
@@ -221,8 +213,8 @@ static void expression(syntax *const sx, node *const nd, int mode)
 			{
 				const int N = node_get_arg(nd, 0);
 
-				tocode(sx, BEGINIT);
-				tocode(sx, N);
+				mem_add(sx, BEGINIT);
+				mem_add(sx, N);
 
 				for (int i = 0; i < N; i++)
 				{
@@ -241,37 +233,37 @@ static void expression(syntax *const sx, node *const nd, int mode)
 			break;
 			case TSliceident:
 			{
-				tocode(sx, LOAD); // параметры - смещение идента и тип элемента
-				tocode(sx, node_get_arg(nd, 0)); // продолжение в след case
+				mem_add(sx, LOAD); // параметры - смещение идента и тип элемента
+				mem_add(sx, node_get_arg(nd, 0)); // продолжение в след case
 			}
 			case TSlice: // параметр - тип элемента
 			{
 				int type = node_get_arg(nd, operation == TSlice ? 0 : 1);
 
 				expression(sx, nd, 0);
-				tocode(sx, SLICE);
-				tocode(sx, size_of(sx, type));
+				mem_add(sx, SLICE);
+				mem_add(sx, size_of(sx, type));
 				if (type > 0 && mode_get(sx, type) == MARRAY)
 				{
-					tocode(sx, LAT);
+					mem_add(sx, LAT);
 				}
 			}
 			break;
 			case TSelect:
 			{
-				tocode(sx, SELECT); // SELECT field_displ
-				tocode(sx, node_get_arg(nd, 0));
+				mem_add(sx, SELECT); // SELECT field_displ
+				mem_add(sx, node_get_arg(nd, 0));
 			}
 			break;
 			case TPrint:
 			{
-				tocode(sx, PRINT);
-				tocode(sx, node_get_arg(nd, 0)); // type
+				mem_add(sx, PRINT);
+				mem_add(sx, node_get_arg(nd, 0)); // type
 			}
 			break;
 			case TCall1:
 			{
-				tocode(sx, CALL1);
+				mem_add(sx, CALL1);
 
 				const int N = node_get_arg(nd, 0);
 				for (int i = 0; i < N; i++)
@@ -282,8 +274,8 @@ static void expression(syntax *const sx, node *const nd, int mode)
 			break;
 			case TCall2:
 			{
-				tocode(sx, CALL2);
-				tocode(sx, ident_get_displ(sx, node_get_arg(nd, 0)));
+				mem_add(sx, CALL2);
+				mem_add(sx, ident_get_displ(sx, node_get_arg(nd, 0)));
 			}
 			break;
 			default:
@@ -308,12 +300,12 @@ static void expression(syntax *const sx, node *const nd, int mode)
 			size_t addr = 0;
 			do
 			{
-				tocode(sx, BE0);
+				mem_add(sx, BE0);
 				const size_t addr_else = mem_size(sx);
 				mem_increase(sx, 1);
 
 				expression(sx, nd, 0); // then
-				tocode(sx, B);
+				mem_add(sx, B);
 				mem_add(sx, (int)addr);
 				addr = mem_size(sx) - 1;
 				mem_set(sx, addr_else, (int)mem_size(sx));
@@ -380,9 +372,9 @@ static void identifier(syntax *const sx, node *const nd)
 	{
 		if (process)
 		{
-			tocode(sx, STRUCTWITHARR);
-			tocode(sx, old_displ);
-			tocode(sx, proc_get(sx, process));
+			mem_add(sx, STRUCTWITHARR);
+			mem_add(sx, old_displ);
+			mem_add(sx, proc_get(sx, process));
 		}
 		if (all) // int a = или struct{} a =
 		{
@@ -391,16 +383,16 @@ static void identifier(syntax *const sx, node *const nd)
 				node_set_next(nd);
 				structure(sx, nd);
 
-				tocode(sx, COPY0STASS);
-				tocode(sx, old_displ);
-				tocode(sx, all); // Общее количество слов
+				mem_add(sx, COPY0STASS);
+				mem_add(sx, old_displ);
+				mem_add(sx, all); // Общее количество слов
 			}
 			else
 			{
 				expression(sx, nd, 0);
 
-				tocode(sx, type == LFLOAT ? ASSRV : ASSV);
-				tocode(sx, old_displ);
+				mem_add(sx, type == LFLOAT ? ASSRV : ASSV);
+				mem_add(sx, old_displ);
 			}
 		}
 	}
@@ -408,24 +400,24 @@ static void identifier(syntax *const sx, node *const nd)
 	{
 		const int length = size_of(sx, type);
 
-		tocode(sx, DEFARR); // DEFARR N, d, displ, iniproc, usual N1...NN, уже лежат на стеке
-		tocode(sx, all == 0 ? N : abs(N) - 1);
-		tocode(sx, length);
-		tocode(sx, old_displ);
-		tocode(sx, proc_get(sx, process));
-		tocode(sx, usual);
-		tocode(sx, all);
-		tocode(sx, instruction);
+		mem_add(sx, DEFARR); // DEFARR N, d, displ, iniproc, usual N1...NN, уже лежат на стеке
+		mem_add(sx, all == 0 ? N : abs(N) - 1);
+		mem_add(sx, length);
+		mem_add(sx, old_displ);
+		mem_add(sx, proc_get(sx, process));
+		mem_add(sx, usual);
+		mem_add(sx, all);
+		mem_add(sx, instruction);
 
 		if (all) // all == 1, если есть инициализация массива
 		{
 			expression(sx, nd, 0);
 
-			tocode(sx, ARRINIT); // ARRINIT N d all displ usual
-			tocode(sx, abs(N));
-			tocode(sx, length);
-			tocode(sx, old_displ);
-			tocode(sx, usual);	// == 0 с пустыми границами
+			mem_add(sx, ARRINIT); // ARRINIT N d all displ usual
+			mem_add(sx, abs(N));
+			mem_add(sx, length);
+			mem_add(sx, old_displ);
+			mem_add(sx, usual);	// == 0 с пустыми границами
 								// == 1 без пустых границ и без инициализации
 		}
 	}
@@ -450,8 +442,8 @@ static int declaration(syntax *const sx, node *const nd)
 
 		case TStructbeg:
 		{
-			tocode(sx, B);
-			tocode(sx, 0);
+			mem_add(sx, B);
+			mem_add(sx, 0);
 			proc_set(sx, node_get_arg(nd, 0), (int)mem_size(sx));
 		}
 		break;
@@ -459,7 +451,7 @@ static int declaration(syntax *const sx, node *const nd)
 		{
 			const int num_proc = node_get_arg(nd, 0);
 
-			tocode(sx, STOP);
+			mem_add(sx, STOP);
 			mem_set(sx, proc_get(sx, num_proc) - 1, (int)mem_size(sx));
 		}
 		break;
@@ -478,12 +470,12 @@ static void statement(syntax *const sx, node *const nd, address *const context)
 		case NOP:
 			break;
 		case CREATEDIRECTC:
-			tocode(sx, CREATEDIRECTC);
+			mem_add(sx, CREATEDIRECTC);
 			sx->max_threads++;
 			break;
 		case EXITDIRECTC:
 		case EXITC:
-			tocode(sx, EXITC);
+			mem_add(sx, EXITC);
 			break;
 		case TBegin:
 			block(sx, nd, context);
@@ -495,7 +487,7 @@ static void statement(syntax *const sx, node *const nd, address *const context)
 			expression(sx, nd, 0);
 			node_set_next(nd); // TExprend
 
-			tocode(sx, BE0);
+			mem_add(sx, BE0);
 			size_t addr = mem_size(sx);
 			mem_increase(sx, 1);
 			statement(sx, nd, context);
@@ -504,7 +496,7 @@ static void statement(syntax *const sx, node *const nd, address *const context)
 			{
 				node_set_next(nd);
 				mem_set(sx, addr, (int)mem_size(sx) + 2);
-				tocode(sx, B);
+				mem_add(sx, B);
 				addr = mem_size(sx);
 				mem_increase(sx, 1);
 				statement(sx, nd, context);
@@ -522,14 +514,14 @@ static void statement(syntax *const sx, node *const nd, address *const context)
 			expression(sx, nd, 0);
 			node_set_next(nd); // TExprend
 
-			tocode(sx, BE0);
+			mem_add(sx, BE0);
 			context->addr_break = mem_size(sx);
 			mem_add(sx, 0);
 			statement(sx, nd, context);
 
 			addr_begin_condition(sx, context, addr);
-			tocode(sx, B);
-			tocode(sx, (int)addr);
+			mem_add(sx, B);
+			mem_add(sx, (int)addr);
 			addr_end_break(sx, context);
 
 			context->addr_break = old_break;
@@ -550,8 +542,8 @@ static void statement(syntax *const sx, node *const nd, address *const context)
 			addr_end_condition(sx, context);
 
 			expression(sx, nd, 0);
-			tocode(sx, BNE0);
-			tocode(sx, (int)addr);
+			mem_add(sx, BNE0);
+			mem_add(sx, (int)addr);
 			addr_end_break(sx, context);
 
 			context->addr_break = old_break;
@@ -583,7 +575,7 @@ static void statement(syntax *const sx, node *const nd, address *const context)
 			if (ref_cond)
 			{
 				expression(sx, &incr, 0); // condition
-				tocode(sx, BE0);
+				mem_add(sx, BE0);
 				context->addr_break = mem_size(sx);
 				mem_add(sx, 0);
 				child_stmt++;
@@ -604,8 +596,8 @@ static void statement(syntax *const sx, node *const nd, address *const context)
 			}
 			node_copy(nd, &stmt);
 
-			tocode(sx, B);
-			tocode(sx, (int)initad);
+			mem_add(sx, B);
+			mem_add(sx, (int)initad);
 			addr_end_break(sx, context);
 
 			context->addr_break = old_break;
@@ -614,7 +606,7 @@ static void statement(syntax *const sx, node *const nd, address *const context)
 		break;
 		case TGoto:
 		{
-			tocode(sx, B);
+			mem_add(sx, B);
 
 			const int id_sign = node_get_arg(nd, 0);
 			const size_t id = id_sign > 0 ? id_sign : -id_sign;
@@ -622,14 +614,14 @@ static void statement(syntax *const sx, node *const nd, address *const context)
 
 			if (addr > 0) // метка уже описана
 			{
-				tocode(sx, addr);
+				mem_add(sx, addr);
 			}
 			else // метка еще не описана
 			{
 				ident_set_displ(sx, id, -(int)mem_size(sx));
 
 				// первый раз встретился переход на еще не описанную метку или нет
-				tocode(sx, id_sign < 0 ? 0 : addr);
+				mem_add(sx, id_sign < 0 ? 0 : addr);
 			}
 		}
 		break;
@@ -677,12 +669,12 @@ static void statement(syntax *const sx, node *const nd, address *const context)
 			{
 				mem_set(sx, context->addr_case, (int)mem_size(sx));
 			}
-			tocode(sx, _DOUBLE);
+			mem_add(sx, _DOUBLE);
 			expression(sx, nd, 0);
 			node_set_next(nd); // TExprend
 
-			tocode(sx, EQEQ);
-			tocode(sx, BE0);
+			mem_add(sx, EQEQ);
+			mem_add(sx, BE0);
 			context->addr_case = mem_size(sx);
 			mem_increase(sx, 1);
 			statement(sx, nd, context);
@@ -702,46 +694,46 @@ static void statement(syntax *const sx, node *const nd, address *const context)
 		break;
 		case TBreak:
 		{
-			tocode(sx, B);
+			mem_add(sx, B);
 			mem_add(sx, (int)context->addr_break);
 			context->addr_break = mem_size(sx) - 1;
 		}
 		break;
 		case TContinue:
 		{
-			tocode(sx, B);
+			mem_add(sx, B);
 			mem_add(sx, (int)context->addr_cond);
 			context->addr_cond = mem_size(sx) - 1;
 		}
 		break;
 		case TReturnvoid:
-			tocode(sx, RETURNVOID);
+			mem_add(sx, RETURNVOID);
 			break;
 		case TReturnval:
 		{
 			const int value = node_get_arg(nd, 0);
 			expression(sx, nd, 0);
 
-			tocode(sx, RETURNVAL);
-			tocode(sx, value);
+			mem_add(sx, RETURNVAL);
+			mem_add(sx, value);
 		}
 		break;
 		case TPrintid:
 		{
-			tocode(sx, PRINTID);
-			tocode(sx, node_get_arg(nd, 0)); // ссылка в identtab
+			mem_add(sx, PRINTID);
+			mem_add(sx, node_get_arg(nd, 0)); // ссылка в identtab
 		}
 		break;
 		case TPrintf:
 		{
-			tocode(sx, PRINTF);
-			tocode(sx, node_get_arg(nd, 0)); // общий размер того, что надо вывести
+			mem_add(sx, PRINTF);
+			mem_add(sx, node_get_arg(nd, 0)); // общий размер того, что надо вывести
 		}
 		break;
 		case TGetid:
 		{
-			tocode(sx, GETID);
-			tocode(sx, node_get_arg(nd, 0)); // ссылка в identtab
+			mem_add(sx, GETID);
+			mem_add(sx, node_get_arg(nd, 0)); // ссылка в identtab
 		}
 		break;
 		case SETMOTOR:
@@ -749,7 +741,7 @@ static void statement(syntax *const sx, node *const nd, address *const context)
 			expression(sx, nd, 0);
 			expression(sx, nd, 0);
 
-			tocode(sx, SETMOTORC);
+			mem_add(sx, SETMOTORC);
 		}
 		break;
 		default:
@@ -788,8 +780,8 @@ static int codegen(syntax *const sx)
 				const int func = ident_get_displ(sx, ref_ident);
 
 				func_set(sx, func, mem_size(sx));
-				tocode(sx, FUNCBEG);
-				tocode(sx, max_displ);
+				mem_add(sx, FUNCBEG);
+				mem_add(sx, max_displ);
 
 				const size_t old_pc = mem_size(sx);
 				mem_increase(sx, 1);
@@ -815,10 +807,10 @@ static int codegen(syntax *const sx)
 		}
 	}
 
-	tocode(sx, CALL1);
-	tocode(sx, CALL2);
-	tocode(sx, ident_get_displ(sx, sx->ref_main));
-	tocode(sx, STOP);
+	mem_add(sx, CALL1);
+	mem_add(sx, CALL2);
+	mem_add(sx, ident_get_displ(sx, sx->ref_main));
+	mem_add(sx, STOP);
 	return 0;
 }
 

--- a/libs/compiler/codegen.c
+++ b/libs/compiler/codegen.c
@@ -929,6 +929,7 @@ void output_export(universal_io *const io, const syntax *const sx)
 	{
 		uni_printf(io, "%i ", sx->reprtab[i]);
 	}
+	uni_printf(io, "\n");
 
 	for (size_t i = 0; i < sx->md; i++)
 	{

--- a/libs/compiler/codegen.c
+++ b/libs/compiler/codegen.c
@@ -564,9 +564,13 @@ static void statement(syntax *const sx, node *const nd, address *const context)
 			size_t old_break = context->addr_break;
 			size_t old_cond = context->addr_cond;
 
+			node incr = *nd;
+			size_t child_stmt = 0;
+
 			if (ref_from)
 			{
-				expression(sx, nd, 0); // initialization
+				expression(sx, &incr, 0); // initialization
+				child_stmt++;
 			}
 
 			size_t initad = mem_size(sx);
@@ -575,30 +579,25 @@ static void statement(syntax *const sx, node *const nd, address *const context)
 
 			if (ref_cond)
 			{
-				expression(sx, nd, 0); // condition
+				expression(sx, &incr, 0); // condition
 				tocode(sx, BE0);
 				context->addr_break = mem_size(sx);
 				mem_add(sx, 0);
+				child_stmt++;
 			}
 
-			node stmt = *nd;
 			if (ref_incr)
 			{
-				node_set_next(&stmt);
-				while (node_get_amount(&stmt) != 0)
-				{
-					const node next = node_get_child(&stmt, node_get_amount(&stmt) - 1);
-					node_copy(&stmt, &next);
-				}
+				child_stmt++;
 			}
 
-			node_set_next(&stmt); // TExprend
+			node stmt = node_get_child(nd, child_stmt);
 			statement(sx, &stmt, context);
 			addr_end_condition(sx, context);
 
 			if (ref_incr)
 			{
-				expression(sx, nd, 0); // increment
+				expression(sx, &incr, 0); // increment
 			}
 			node_copy(nd, &stmt);
 

--- a/libs/compiler/codegen.c
+++ b/libs/compiler/codegen.c
@@ -234,6 +234,7 @@ int Expr_gen(syntax *const sx, int incond)
 				for (i = 0; i < n; i++)
 				{
 					Expr_gen(sx, 0);
+					tree_next_node(sx); // TExpend
 				}
 				break;
 			}
@@ -247,6 +248,7 @@ int Expr_gen(syntax *const sx, int incond)
 				for (i = 0; i < n; i++)
 				{
 					Expr_gen(sx, 0);
+					tree_next_node(sx); // TExprend
 				}
 				break;
 			}
@@ -261,6 +263,7 @@ int Expr_gen(syntax *const sx, int incond)
 
 				tree_next_node(sx);
 				Expr_gen(sx, 0);
+				tree_next_node(sx); // TExprend
 				tocode(sx, SLICE);
 				tocode(sx, size_of(sx, eltype));
 				if (eltype > 0 && mode_get(sx, eltype) == MARRAY)
@@ -294,6 +297,7 @@ int Expr_gen(syntax *const sx, int incond)
 				for (i = 0; i < n; i++)
 				{
 					Expr_gen(sx, 0);
+					tree_next_node(sx); // TExprend
 				}
 				break;
 			}
@@ -329,6 +333,7 @@ int Expr_gen(syntax *const sx, int incond)
 					mem_increase(sx, 1);
 					tree_next_node(sx);
 					Expr_gen(sx, 0); // then
+					tree_next_node(sx); // TExprend
 					tocode(sx, B);
 					mem_add(sx, (int)ad);
 					ad = mem_get_size(sx) - 1;
@@ -347,7 +352,7 @@ int Expr_gen(syntax *const sx, int incond)
 			finalop(sx);
 		}
 	}
-	tree_next_node(sx);
+	//tree_next_node(sx);
 	return wasstring;
 }
 
@@ -392,7 +397,7 @@ void Stmt_gen(syntax *const sx, ad *const context)
 		}
 		case TBegin:
 		{
-			tree_next_node(sx);
+			tree_next_node(sx); // TBegin
 			compstmt_gen(sx, context);
 			tree_next_node(sx); // TEnd
 			break;
@@ -403,6 +408,7 @@ void Stmt_gen(syntax *const sx, ad *const context)
 
 			tree_next_node(sx);
 			Expr_gen(sx, 0);
+			tree_next_node(sx); // TExprend
 			tocode(sx, BE0);
 			size_t ad = mem_get_size(sx);
 			mem_increase(sx, 1);
@@ -427,6 +433,7 @@ void Stmt_gen(syntax *const sx, ad *const context)
 			tree_next_node(sx);
 			context->adcont = ad;
 			Expr_gen(sx, 0);
+			tree_next_node(sx); // TExprend
 			tocode(sx, BE0);
 			context->adbreak = mem_get_size(sx);
 			mem_add(sx, 0);	
@@ -453,6 +460,7 @@ void Stmt_gen(syntax *const sx, ad *const context)
 			Stmt_gen(sx, context);
 			adcontend(sx, context);
 			Expr_gen(sx, 0);
+			tree_next_node(sx); // TExprend
 			tocode(sx, BNE0);
 			tocode(sx, (int)ad);
 			adbreakend(sx, context);
@@ -477,6 +485,7 @@ void Stmt_gen(syntax *const sx, ad *const context)
 			if (ref_from)
 			{
 				Expr_gen(sx, 0); // init
+				tree_next_node(sx); // TExprend
 				child_stmt++;
 			}
 
@@ -487,6 +496,7 @@ void Stmt_gen(syntax *const sx, ad *const context)
 			if (ref_cond)
 			{
 				Expr_gen(sx, 0); // cond
+				tree_next_node(sx); // TExprend
 				tocode(sx, BE0);
 				context->adbreak = mem_get_size(sx);
 				mem_add(sx, 0);
@@ -507,7 +517,8 @@ void Stmt_gen(syntax *const sx, ad *const context)
 			{
 				node incr = node_get_child(tfor, child_stmt - 1);
 				tree_set_node(sx, &incr);
-				Expr_gen(sx, 0); // incr	
+				Expr_gen(sx, 0); // incr
+				tree_next_node(sx); // TExprend
 			}
 
 			*tfor = temp;
@@ -570,6 +581,7 @@ void Stmt_gen(syntax *const sx, ad *const context)
 
 			tree_next_node(sx);
 			Expr_gen(sx, 0);
+			tree_next_node(sx); // TExprend
 			Stmt_gen(sx, context);
 			if (context->adcase > 0)
 			{
@@ -590,6 +602,7 @@ void Stmt_gen(syntax *const sx, ad *const context)
 
 			tree_next_node(sx);
 			Expr_gen(sx, 0);
+			tree_next_node(sx); // TExprend
 			tocode(sx, EQEQ);
 			tocode(sx, BE0);
 			context->adcase = mem_get_size(sx);
@@ -638,6 +651,7 @@ void Stmt_gen(syntax *const sx, ad *const context)
 			tree_next_node(sx);
 
 			Expr_gen(sx, 0);
+			tree_next_node(sx); // TExprend
 			tocode(sx, RETURNVAL);
 			tocode(sx, d);
 			break;
@@ -668,13 +682,16 @@ void Stmt_gen(syntax *const sx, ad *const context)
 		{
 			tree_next_node(sx);
 			Expr_gen(sx, 0);
+			tree_next_node(sx); // TExprend
 			Expr_gen(sx, 0);
+			tree_next_node(sx); // TExprend
 			tocode(sx, SETMOTORC);
 			break;
 		}
 		default:
 		{
 			Expr_gen(sx, 0);
+			tree_next_node(sx); // TExprend
 			break;
 		}
 	}
@@ -701,6 +718,7 @@ void Struct_init_gen(syntax *const sx)
 	else
 	{
 		Expr_gen(sx, 0);
+		tree_next_node(sx); // TExprend
 	}
 }
 
@@ -742,6 +760,7 @@ void Declid_gen(syntax *const sx)
 			else
 			{
 				Expr_gen(sx, 0);
+				tree_next_node(sx); // TExprend
 				tocode(sx, telem == LFLOAT ? ASSRV : ASSV);
 				tocode(sx, olddispl);
 			}
@@ -762,6 +781,7 @@ void Declid_gen(syntax *const sx)
 		if (all) // all == 1, если есть инициализация массива
 		{
 			Expr_gen(sx, 0);
+			tree_next_node(sx); // TExprend
 			tocode(sx, ARRINIT); // ARRINIT N d all displ usual
 			tocode(sx, abs(N));
 			tocode(sx, element_len);
@@ -787,6 +807,7 @@ void compstmt_gen(syntax *const sx, ad *const context)
 				for (int i = 0; i < N; i++)
 				{
 					Expr_gen(sx, 0);
+					tree_next_node(sx); // TExprend
 				}
 				break;
 			}
@@ -850,6 +871,7 @@ int codegen(syntax *const sx)
 				for (int i = 0; i < N; i++)
 				{
 					Expr_gen(sx, 0);
+					tree_next_node(sx); // TExprend
 				}
 				break;
 			}

--- a/libs/compiler/codegen.c
+++ b/libs/compiler/codegen.c
@@ -814,7 +814,7 @@ static int codegen(syntax *const sx)
 			{
 				if (declaration(sx))
 				{
-					printf("tc=%zi tree[tc-2]=%i tree[tc-1]=%i\n", sx->tc, sx->tree[sx->tc - 2], sx->tree[sx->tc - 1]);
+					error(NULL, node_unexpected, node_get_type(tree_get_node(sx)));
 					return -1;
 				}
 			}

--- a/libs/compiler/errors.c
+++ b/libs/compiler/errors.c
@@ -647,6 +647,13 @@ void get_error(const int num, char *const msg, va_list args)
 			sprintf(msg, "невозможно добавить аргумент %i для tree[%zi] = %i", arg, i, elem);
 		}
 		break;
+		case node_unexpected:
+		{
+			const int type = va_arg(args, int);
+			sprintf(msg, "недопустимый узел верхнего уровня %i", type);
+
+		}
+		break;
 
 		default:
 			sprintf(msg, "этот код ошибки я прозевал");

--- a/libs/compiler/errors.h
+++ b/libs/compiler/errors.h
@@ -184,6 +184,7 @@ enum ERROR
 	node_cannot_set_child,
 	node_cannot_set_type,
 	node_cannot_add_arg,
+	node_unexpected,
 };
 
 /** Warnings codes */

--- a/libs/compiler/syntax.c
+++ b/libs/compiler/syntax.c
@@ -107,7 +107,7 @@ int sx_init(syntax *const sx)
 	sx->rp = 1;
 
 	sx->maxdisplg = 3;
-	sx->main_ref = 0;
+	sx->ref_main = 0;
 
 	sx->maxdispl = 3;
 	sx->displ = -3;
@@ -129,7 +129,7 @@ int sx_init(syntax *const sx)
 int sx_is_correct(syntax *const sx, universal_io *const io)
 {
 	int is_correct = 1;
-	if (sx->main_ref == 0)
+	if (sx->ref_main == 0)
 	{
 		error(io, no_main_in_program);
 		is_correct = 0;
@@ -287,11 +287,11 @@ size_t ident_add(syntax *const sx, const size_t repr, const int type, const int 
 
 	if (repr_get_reference(sx, repr) == 0) // это может быть только MAIN
 	{
-		if (sx->main_ref)
+		if (sx->ref_main)
 		{
 			return SIZE_MAX;
 		}
-		sx->main_ref = lastid;
+		sx->ref_main = lastid;
 	}
 
 	// Ссылка на описание с таким же представлением в предыдущем блоке

--- a/libs/compiler/syntax.c
+++ b/libs/compiler/syntax.c
@@ -122,6 +122,7 @@ int sx_init(syntax *const sx)
 	}
 
 	sx->current = NULL;
+	sx->max_threads = 0;
 
 	return 0;
 }

--- a/libs/compiler/syntax.c
+++ b/libs/compiler/syntax.c
@@ -121,7 +121,6 @@ int sx_init(syntax *const sx)
 		sx->hashtab[i] = 0;
 	}
 
-	sx->current = NULL;
 	sx->max_threads = 0;
 
 	return 0;
@@ -617,31 +616,4 @@ int scope_func_exit(syntax *const sx, const size_t decl_ref, const int displ)
 	sx->displ = displ;
 	
 	return 0;
-}
-
-
-int tree_set_node(syntax *const sx, node *const nd)
-{
-	if (sx == NULL || !node_is_correct(nd))
-	{
-		return -1;
-	}
-
-	sx->current = nd;
-	return 0;
-}
-
-int tree_next_node(syntax *const sx)
-{
-	return sx != NULL ? node_set_next(sx->current) : -1;
-}
-
-node *tree_get_node(syntax *const sx)
-{
-	if (sx == NULL || !node_is_correct(sx->current))
-	{
-		return NULL;
-	}
-
-	return sx->current;
 }

--- a/libs/compiler/syntax.c
+++ b/libs/compiler/syntax.c
@@ -191,7 +191,7 @@ int mem_get(const syntax *const sx, const size_t index)
 	return sx->mem[index];
 }
 
-size_t mem_get_size(const syntax *const sx)
+size_t mem_size(const syntax *const sx)
 {
 	if (sx == NULL)
 	{

--- a/libs/compiler/syntax.h
+++ b/libs/compiler/syntax.h
@@ -76,8 +76,6 @@ typedef struct syntax
 	int keywordsnum;				/**< Number of read keyword */
 
 	size_t max_threads;				/**< Max threads count */
-
-	node *current; 					/**< Current node during traversing the tree */
 } syntax;
 
 
@@ -429,37 +427,6 @@ int scope_func_enter(syntax *const sx);
  *	@return	@c 0 on success, @c -1 on failure
  */
 int scope_func_exit(syntax *const sx, const size_t decl_ref, const int displ);
-
-  
-/**
- *	Set current node
- *
- *	@param	sx			Syntax structure
- *	@param	nd			Node to set
- *
- *	@return	@c 0 on success, @c -1 on failure
- */
-int tree_set_node(syntax *const sx, node *const nd);
-
-/**
- *	Set next node in current node
- *
- *	@param	sx			Syntax structure
- *
- *	@return	@c -1 on failure, 
- *			@c  0 on success,
- *			@c  1 on the end of the tree
- */
-int tree_next_node(syntax *const sx);
-
-/**
- *	Get current node
- *
- *	@param	sx			Syntax structure
- *
- *	@return	Current node, @c NULL on failure
- */
-node *tree_get_node(syntax *const sx);
 
 #ifdef __cplusplus
 } /* extern "C" */

--- a/libs/compiler/syntax.h
+++ b/libs/compiler/syntax.h
@@ -32,7 +32,7 @@ typedef struct node node;
 /** Global vars definition */
 typedef struct syntax
 {
-	// mem, pc & iniprocs - usage here only for codes printing
+	// mem, pc, iniprocs & max_threads - usage here only for codes printing
 
 	int mem[MAXMEMSIZE];			/**< Memory */
 	int pc;							/**< Program counter */
@@ -74,6 +74,8 @@ typedef struct syntax
 	int lg;							/**< Displacement from l (+1) or g (-1) */
 	
 	int keywordsnum;				/**< Number of read keyword */
+
+	size_t max_threads;				/**< Max threads count */
 
 	node *current; 					/**< Current node during traversing the tree */
 } syntax;

--- a/libs/compiler/syntax.h
+++ b/libs/compiler/syntax.h
@@ -68,7 +68,7 @@ typedef struct syntax
 
 	int maxdispl;					/**< Max displacement */
 	int maxdisplg;					/**< Max displacement */
-	size_t main_ref;				/**< Main function reference */
+	size_t ref_main;				/**< Main function reference */
 
 	int displ;						/**< Stack displacement in current scope */
 	int lg;							/**< Displacement from l (+1) or g (-1) */

--- a/libs/compiler/syntax.h
+++ b/libs/compiler/syntax.h
@@ -147,7 +147,7 @@ int mem_get(const syntax *const sx, const size_t index);
  *
  *	@return	Program counter on success, @c INT_MAX on failure
  */
-size_t mem_get_size(const syntax *const sx);
+size_t mem_size(const syntax *const sx);
 
 
 /**

--- a/libs/compiler/tree.c
+++ b/libs/compiler/tree.c
@@ -769,6 +769,17 @@ node node_set_child(node *const nd)
 }
 
 
+int node_copy(node *const dest, const node *const src)
+{
+	if (!node_is_correct(src) || dest == NULL)
+	{
+		return -1;
+	}
+
+	*dest = *src;
+	return 0;
+}
+
 int node_is_correct(const node *const nd)
 {
 	return nd != NULL && tree_is_correct(&nd->tree);

--- a/libs/compiler/tree.h
+++ b/libs/compiler/tree.h
@@ -164,6 +164,16 @@ node node_set_child(node *const nd);
 
 
 /**
+ *	Copy source node to destination
+ *
+ *	@param	dest	Destination node
+ *	@param	src		Source node
+ *
+ *	@return	@c 0 on success, @c -1 on failure
+ */
+int node_copy(node *const dest, const node *const src);
+
+/**
  *	Check that node is correct
  *
  *	@param	nd		Node structure

--- a/libs/utils/vector.c
+++ b/libs/utils/vector.c
@@ -79,17 +79,6 @@ size_t vector_add(vector *const vec, const item_t value)
 	return vec->size++;
 }
 
-int vector_remove(vector *const vec)
-{
-	if (!vector_is_correct(vec) || vec->size == 0)
-	{
-		return -1;
-	}
-
-	vec->size--;
-	return 0;
-}
-
 int vector_set(vector *const vec, const size_t index, const item_t value)
 {
 	if (!vector_is_correct(vec) || index >= vec->size)
@@ -109,6 +98,16 @@ item_t vector_get(const vector *const vec, const size_t index)
 	}
 
 	return vec->array[index];
+}
+
+item_t vector_remove(vector *const vec)
+{
+	if (!vector_is_correct(vec) || vec->size == 0)
+	{
+		return ITEM_MAX;
+	}
+
+	return vec->array[--vec->size];
 }
 
 

--- a/libs/utils/vector.h
+++ b/libs/utils/vector.h
@@ -65,15 +65,6 @@ EXPORTED int vector_increase(vector *const vec, const size_t size);
 EXPORTED size_t vector_add(vector *const vec, const item_t value);
 
 /**
- *	Remove last value
- *
- *	@param	vec				Vector structure
- *
- *	@return	@c 0 on success, @c -1 on failure
- */
-EXPORTED int vector_remove(vector *const vec);
-
-/**
  *	Set new value
  *
  *	@param	vec				Vector structure
@@ -93,6 +84,15 @@ EXPORTED int vector_set(vector *const vec, const size_t index, const item_t valu
  *	@return	Value, @c ITEM_MAX on failure
  */
 EXPORTED item_t vector_get(const vector *const vec, const size_t index);
+
+/**
+ *	Remove last value
+ *
+ *	@param	vec				Vector structure
+ *
+ *	@return	Deleted value, @c ITEM_MAX on failure
+ */
+EXPORTED item_t vector_remove(vector *const vec);
 
 
 


### PR DESCRIPTION
- Указатель на текущую `node` перенесен в аргументы функций
- Удалены дублирующие интерфейсы `tree_*_node(syntax *sx, ...)`
- Уменьшено количество переключений `node`, функций `node_set_next(node *nd)`
- Добавлены модификаторы `static` и `const`
- Проведен рефакторинг имен:
  - Улучшено именование переменных
  - Названия функций приведены к одному формату
  - Переименованы интерфейсы взаимодействия со структурой адресов
- Неиспользуемое поле `main`-ссылки переопределено под максимальное количество потоков VM
- Добавлена функция копирования `node`
- Обновлен интерфейс `vector_remove(vector *vec)`, для упрощения организации стека
- Введены новые флаги тестовой системы:
  - `-f`, `--fast` для ускорения тестирования (отключает `Debug` тесты)
  - `-r`, `--remove` для принудительного удаления папки `build`