### PR TITLE
Обновление интерфейса узлов

### DIFF
--- a/libs/compiler/errors.c
+++ b/libs/compiler/errors.c
@@ -517,6 +517,12 @@ void get_error(const error_t num, char *const msg, va_list args)
 		case not_array_in_stanfunc:	// need_test
 			sprintf(msg, "в этой операции этот параметр должен иметь тип массив");
 			break;
+		case default_not_in_switch:
+			sprintf(msg, "метка УМОЛЧАНИЕ не в операторе ВЫБОР");
+			break;
+		case expected_colon_after_default:
+			sprintf(msg, "после метки УМОЛЧАНИЕ нет :");
+			break;
 
 		case tree_expression_not_block:
 		{
@@ -558,11 +564,11 @@ void get_error(const error_t num, char *const msg, va_list args)
 		}
 		break;
 
-		case node_cannot_set_child:
+		case node_cannot_add_child:
 		{
 			const size_t i = va_arg(args, size_t);
 			const item_t elem = va_arg(args, item_t);
-			sprintf(msg, "невозможно получить потомка от tree[%zi] = %" PRIitem, i, elem);
+			sprintf(msg, "невозможно добавить потомка к tree[%zi] = %" PRIitem, i, elem);
 		}
 		break;
 		case node_cannot_set_type:
@@ -590,12 +596,6 @@ void get_error(const error_t num, char *const msg, va_list args)
 
 		case tables_cannot_be_compressed:
 			sprintf(msg, "невозможно сжать таблицы до заданного размера");
-			break;
-		case default_not_in_switch:
-			sprintf(msg, "метка УМОЛЧАНИЕ не в операторе ВЫБОР");
-			break;
-		case expected_colon_after_default:
-			sprintf(msg, "после метки УМОЛЧАНИЕ нет :");
 			break;
 
 		default:

--- a/libs/compiler/errors.h
+++ b/libs/compiler/errors.h
@@ -186,7 +186,7 @@ typedef enum ERROR
 	tree_no_tend,
 	tree_unexpected,
 
-	node_cannot_set_child,
+	node_cannot_add_child,
 	node_cannot_set_type,
 	node_cannot_add_arg,
 	node_unexpected,

--- a/libs/compiler/tree.c
+++ b/libs/compiler/tree.c
@@ -765,6 +765,23 @@ int node_copy(node *const dest, const node *const src)
 	return 0;
 }
 
+size_t node_save(node *const nd)
+{
+	return node_is_correct(nd) ? nd->type : SIZE_MAX;
+}
+
+node node_load(vector *const tree, const size_t index)
+{
+	if (!vector_is_correct(tree) || index >= vector_size(tree))
+	{
+		return node_broken();
+	}
+
+	return is_operator(vector_get(tree, index))
+		? node_operator(tree, index)
+		: node_expression(tree, index);
+}
+
 int node_order(node *const fst, const size_t fst_index, node *const snd, const size_t snd_index)
 {
 	if (!node_is_correct(fst) || !node_is_correct(snd) || fst->tree != snd->tree

--- a/libs/compiler/tree.c
+++ b/libs/compiler/tree.c
@@ -587,7 +587,6 @@ node node_get_root(vector *const tree)
 	nd.argc = 0;
 	nd.children = 0;
 	nd.amount = 0;
-	nd.parent = SIZE_MAX;
 
 	size_t i = 0;
 	while (i != SIZE_MAX && vector_get(nd.tree, i) != ITEM_MAX)
@@ -624,12 +623,9 @@ node node_get_child(node *const nd, const size_t index)
 		}
 	}
 
-	node child = nd->type == SIZE_MAX || is_operator(node_get_type(nd))
+	return nd->type == SIZE_MAX || is_operator(node_get_type(nd))
 		? node_operator(nd->tree, i)
 		: node_expression(nd->tree, i);
-
-	child.parent = nd->type;
-	return child;
 }
 
 
@@ -760,7 +756,6 @@ node node_set_child(node *const nd)
 	child.children = child.argv + child.argc;
 	child.amount = 0;
 
-	child.parent = nd->type;
 	return child;
 }
 

--- a/libs/compiler/tree.c
+++ b/libs/compiler/tree.c
@@ -531,7 +531,7 @@ int node_test_copy(node *const dest, node *const nd)
 	node child_dest = node_add_child(dest, node_get_type(nd));
 	if (!node_is_correct(&child_dest))
 	{
-		system_error(node_cannot_set_child, dest->type, node_get_type(dest));
+		system_error(node_cannot_add_child, dest->type, node_get_type(dest));
 		return -1;
 	}
 

--- a/libs/compiler/tree.h
+++ b/libs/compiler/tree.h
@@ -167,6 +167,25 @@ int node_set_arg(node *const nd, const size_t index, const item_t arg);
 int node_copy(node *const dest, const node *const src);
 
 /**
+ *	Save internal node index
+ *
+ *	@param	nd			Node structure
+ *
+ *	@return	Internal index, @c SIZE_MAX on failure
+ */
+size_t node_save(node *const nd);
+
+/**
+ *	Rebuild node by internal index
+ *
+ *	@param	tree		Tree table
+ *	@param	index		Internal index
+ *
+ *	@return	Rebuilt node
+ */
+node node_load(vector *const tree, const size_t index);
+
+/**
  *	Change only node order
  *
  *	@param	fst			First parent node

--- a/libs/compiler/tree.h
+++ b/libs/compiler/tree.h
@@ -36,8 +36,6 @@ typedef struct node
 
 	size_t children;		/**< Reference to children */
 	size_t amount;			/**< Amount of children */
-
-	size_t parent;			/**< Reference to parent */
 } node;
 
 

--- a/libs/compiler/tree.h
+++ b/libs/compiler/tree.h
@@ -108,6 +108,16 @@ int node_set_next(node *const nd);
 
 
 /**
+ *	Add child node
+ *
+ *	@param	nd			Current node
+ *	@param	type		Child node type
+ *
+ *	@return	Child node
+ */
+node node_add_child(node *const nd, const item_t type);
+
+/**
  *	Set node type
  *
  *	@param	nd			Node structure
@@ -115,8 +125,7 @@ int node_set_next(node *const nd);
  *
  *	@return	@c  0 on success,
  *			@c -1 on failure,
- *			@c -2 on trying to reset the root node,
- *			@c -3 on trying to set non-empty node
+ *			@c -2 on trying to reset the root node
  */
 int node_set_type(node *const nd, const item_t type);
 
@@ -128,7 +137,7 @@ int node_set_type(node *const nd, const item_t type);
  *
  *	@return	@c  0 on success,
  *			@c -1 on failure,
- *			@c -2 on root or types not set node,
+ *			@c -2 on root,
  *			@c -3 on node with children
  */
 int node_add_arg(node *const nd, const item_t arg);
@@ -142,18 +151,9 @@ int node_add_arg(node *const nd, const item_t arg);
  *
  *	@return	@c  0 on success,
  *			@c -1 on failure,
- *			@c -2 on root or types not set node
+ *			@c -2 on root
  */
 int node_set_arg(node *const nd, const size_t index, const item_t arg);
-
-/**
- *	Set child node
- *
- *	@param	nd			Current node
- *
- *	@return	Child node
- */
-node node_set_child(node *const nd);
 
 
 /**


### PR DESCRIPTION
- Удалены нерабочие ссылки на родителя
- Функция `node_set_child` заменена на `node_add_child`
- Добавлен интерфейс сохранения/восстановления узлов дерева по индексу:
```c
/**
 *	Save internal node index
 *
 *	@param	nd			Node structure
 *
 *	@return	Internal index, @c SIZE_MAX on failure
 */
size_t node_save(node *const nd);

/**
 *	Rebuild node by internal index
 *
 *	@param	tree		Tree table
 *	@param	index		Internal index
 *
 *	@return	Rebuilt node
 */
node node_load(vector *const tree, const size_t index);
```