### PR TITLE
Объявления внутри for

### DIFF
--- a/libs/compiler/codegen.c
+++ b/libs/compiler/codegen.c
@@ -648,7 +648,11 @@ static void statement(virtual *const vm, node *const nd)
 
 			if (ref_from)
 			{
-				expression(vm, &incr, 0); // initialization
+				node_set_next(&incr);
+				if (declaration(vm, &incr))
+				{
+					expression(vm, &incr, -1);
+				}
 				child_stmt++;
 			}
 

--- a/libs/compiler/lexer.c
+++ b/libs/compiler/lexer.c
@@ -133,7 +133,7 @@ static token_t lex_identifier_or_keyword(lexer *const lxr)
 
 	const size_t repr = repr_reserve(lxr->sx, spelling);
 	const item_t ref = repr_get_reference(lxr->sx, repr);
-	if (ref >= 0)
+	if (ref >= 0 && repr != ITEM_MAX)
 	{
 		lxr->repr = repr;
 		return identifier;

--- a/libs/compiler/parser.h
+++ b/libs/compiler/parser.h
@@ -25,7 +25,7 @@
 #include "uniio.h"
 
 
-#define GENERATE_TREE
+//#define GENERATE_TREE
 
 
 #ifdef __cplusplus

--- a/libs/compiler/parser.h
+++ b/libs/compiler/parser.h
@@ -25,7 +25,7 @@
 #include "uniio.h"
 
 
-//#define GENERATE_TREE
+#define GENERATE_TREE
 
 
 #ifdef __cplusplus
@@ -47,6 +47,7 @@ typedef enum BLOCK
 	REGBLOCK,
 	THREAD,
 	FUNCBODY,
+	FORBLOCK,
 } block_t;
 
 

--- a/libs/compiler/parser_decl.c
+++ b/libs/compiler/parser_decl.c
@@ -694,7 +694,7 @@ void parse_function_body(parser *const prs, node *const parent, const size_t fun
 	prs->flag_was_return = 0;
 
 	const item_t prev = ident_get_prev(prs->sx, function_id);
-	if (prev > 1) // Был прототип
+	if (prev > 1 && prev != ITEM_MAX) // Был прототип
 	{
 		if (prs->function_mode != (size_t)ident_get_mode(prs->sx, (size_t)prev))
 		{

--- a/libs/compiler/parser_expr.c
+++ b/libs/compiler/parser_expr.c
@@ -730,21 +730,21 @@ void parse_standard_function_call(parser *const prs)
  */
 size_t parse_identifier(parser *const prs)
 {
-	const size_t id = (size_t)repr_get_reference(prs->sx, prs->lxr->repr);
-	if (id == ITEM_MAX)
+	const item_t ref = repr_get_reference(prs->sx, prs->lxr->repr);
+	if (ref == ITEM_MAX)
 	{
 		parser_error(prs, ident_is_not_declared, repr_get_name(prs->sx, prs->lxr->repr));
 	}
 
 	to_tree(prs, TIdent);
+
+	const size_t id = (size_t)ref;
 	prs->operand_displ = ident_get_displ(prs->sx, id);
 	node_add_arg(&prs->nd, prs->operand_displ);
 
-	const item_t mode = ident_get_mode(prs->sx, id);
-
 	prs->last_id = id;
 	token_consume(prs);
-	operands_push(prs, VARIABLE, mode);
+	operands_push(prs, VARIABLE, ident_get_mode(prs->sx, id));
 	return id;
 }
 

--- a/libs/compiler/parser_expr.c
+++ b/libs/compiler/parser_expr.c
@@ -730,22 +730,21 @@ void parse_standard_function_call(parser *const prs)
  */
 size_t parse_identifier(parser *const prs)
 {
-	const item_t ref = repr_get_reference(prs->sx, prs->lxr->repr);
-	if (ref == ITEM_MAX)
+	const item_t id = repr_get_reference(prs->sx, prs->lxr->repr);
+	if (id == ITEM_MAX)
 	{
 		parser_error(prs, ident_is_not_declared, repr_get_name(prs->sx, prs->lxr->repr));
 	}
 
 	to_tree(prs, TIdent);
 
-	const size_t id = (size_t)ref;
-	prs->operand_displ = ident_get_displ(prs->sx, id);
+	prs->operand_displ = ident_get_displ(prs->sx, (size_t)id);
 	node_add_arg(&prs->nd, prs->operand_displ);
 
-	prs->last_id = id;
+	prs->last_id = (size_t)id;
 	token_consume(prs);
-	operands_push(prs, VARIABLE, ident_get_mode(prs->sx, id));
-	return id;
+	operands_push(prs, VARIABLE, ident_get_mode(prs->sx, (size_t)id));
+	return (size_t)id;
 }
 
 /**

--- a/libs/compiler/parser_stmt.c
+++ b/libs/compiler/parser_stmt.c
@@ -297,7 +297,15 @@ void parse_for_statement(parser *const prs, node *const parent)
 	if (!token_try_consume(prs, semicolon))
 	{
 		node_set_arg(&nd, 0, 1); // ref_inition
-		is_declaration_specifier(prs) ? parse_declaration_inner(prs, &nd) : parse_expression_statement(prs, &nd);
+		if (is_declaration_specifier(prs))
+		{
+			parse_declaration_inner(prs, &nd);
+		}
+		else
+		{
+			parse_expression(prs, &nd);
+			token_expect_and_consume(prs, r_paren, no_semicolon_in_for);
+		}
 	}
 
 	if (!token_try_consume(prs, semicolon))
@@ -790,7 +798,14 @@ void parse_statement_compound(parser *const prs, node *const parent, const block
 		while (prs->token != eof && prs->token != end_token)
 		{
 			// Почему не ловилась ошибка, если в блоке нити встретилась '}'?
-			is_declaration_specifier(prs) ? parse_declaration_inner(prs, &nd_block) : parse_statement(prs, &nd_block);
+			if (is_declaration_specifier(prs))
+			{
+				parse_declaration_inner(prs, &nd_block);
+			}
+			else
+			{
+				parse_statement(prs, &nd_block);
+			}
 		}
 
 		token_expect_and_consume(prs, end_token, expected_end);

--- a/libs/compiler/parser_stmt.c
+++ b/libs/compiler/parser_stmt.c
@@ -304,7 +304,7 @@ void parse_for_statement(parser *const prs, node *const parent)
 		else
 		{
 			parse_expression(prs, &nd);
-			token_expect_and_consume(prs, r_paren, no_semicolon_in_for);
+			token_expect_and_consume(prs, semicolon, no_semicolon_in_for);
 		}
 	}
 

--- a/libs/compiler/parser_stmt.c
+++ b/libs/compiler/parser_stmt.c
@@ -36,16 +36,13 @@ int is_declaration_specifier(parser *const prs)
 
 		case identifier:
 		{
-			const item_t ref = repr_get_reference(prs->sx, prs->lxr->repr);
-			const size_t id = ref == ITEM_MAX ? 1 : (size_t)ref;
-			if (ident_get_displ(prs->sx, id) >= 1000)
-			{
-				return 1;
-			}
-			else
+			const item_t id = repr_get_reference(prs->sx, prs->lxr->repr);
+			if (id == ITEM_MAX)
 			{
 				return 0;
 			}
+
+			return ident_get_displ(prs->sx, (size_t)id) >= 1000;
 		}
 
 		default:

--- a/libs/compiler/syntax.c
+++ b/libs/compiler/syntax.c
@@ -340,7 +340,7 @@ size_t ident_add(syntax *const sx, const size_t repr, const item_t type, const i
 {
 	const size_t last_id = vector_size(&sx->identifiers);
 	const item_t ref = repr_get_reference(sx, repr);
-	vector_add(&sx->identifiers, ref == ITEM_MAX ? 1 : ref);
+	vector_add(&sx->identifiers, ref);
 	vector_increase(&sx->identifiers, 3);
 
 	if (ref == 0) // это может быть только MAIN
@@ -362,7 +362,7 @@ size_t ident_add(syntax *const sx, const size_t repr, const item_t type, const i
 	}
 
 	// Один и тот же идентификатор м.б. переменной и меткой
-	if (type != 1 && prev >= sx->cur_id && (func_def != 1 || ident_get_repr(sx, prev) > 0))
+	if (type != 1 && prev != ITEM_MAX && prev >= sx->cur_id && (func_def != 1 || ident_get_repr(sx, prev) > 0))
 	{
 		// Только определение функции может иметь 2 описания, то есть иметь предописание
 		return SIZE_MAX - 1;
@@ -547,8 +547,7 @@ int scope_block_exit(syntax *const sx, const item_t displ, const item_t lg)
 
 	for (size_t i = vector_size(&sx->identifiers) - 4; i >= sx->cur_id; i -= 4)
 	{
-		const item_t prev = ident_get_prev(sx, i);
-		repr_set_reference(sx, (size_t)ident_get_repr(sx, i), prev == 1 ? ITEM_MAX : prev);
+		repr_set_reference(sx, (size_t)ident_get_repr(sx, i), ident_get_prev(sx, i));
 	}
 
 	sx->displ = displ;

--- a/libs/compiler/syntax.c
+++ b/libs/compiler/syntax.c
@@ -547,7 +547,8 @@ int scope_block_exit(syntax *const sx, const item_t displ, const item_t lg)
 
 	for (size_t i = vector_size(&sx->identifiers) - 4; i >= sx->cur_id; i -= 4)
 	{
-		repr_set_reference(sx, (size_t)ident_get_repr(sx, i), vector_get(&sx->identifiers, i));
+		const item_t prev = ident_get_prev(sx, i);
+		repr_set_reference(sx, (size_t)ident_get_repr(sx, i), prev == 1 ? ITEM_MAX : prev);
 	}
 
 	sx->displ = displ;

--- a/libs/compiler/syntax.c
+++ b/libs/compiler/syntax.c
@@ -362,7 +362,8 @@ size_t ident_add(syntax *const sx, const size_t repr, const item_t type, const i
 	}
 
 	// Один и тот же идентификатор м.б. переменной и меткой
-	if (type != 1 && prev != ITEM_MAX && prev >= sx->cur_id && (func_def != 1 || ident_get_repr(sx, prev) > 0))
+	if (type != 1 && ident_get_prev(sx, last_id) != ITEM_MAX
+		&& prev >= sx->cur_id && (func_def != 1 || ident_get_repr(sx, prev) > 0))
 	{
 		// Только определение функции может иметь 2 описания, то есть иметь предописание
 		return SIZE_MAX - 1;

--- a/tests/errors/compiler/for_inner_declaration/outside_of_for_scope.c
+++ b/tests/errors/compiler/for_inner_declaration/outside_of_for_scope.c
@@ -1,0 +1,6 @@
+void main()
+{
+	for (int i = 0; i < 10; i++);
+
+	i = 10;
+}

--- a/tests/errors/compiler/outside_of_scope.c
+++ b/tests/errors/compiler/outside_of_scope.c
@@ -1,0 +1,8 @@
+int main()
+{
+	{
+		int i = 0;
+	}
+	i = 10;
+	return 1;
+}

--- a/tests/executable/cicles/for/inner_declaration.c
+++ b/tests/executable/cicles/for/inner_declaration.c
@@ -1,0 +1,14 @@
+void main()
+{
+	int a = 0;
+	for (int i = 0; i < 10; i++)
+		a++;
+	assert(a == 10, "Must be 10");
+
+	a = 0;
+	for (int i = 0; i < 10; i++)
+	{
+		a++;
+	}
+	assert(a == 10, "Must be 10");
+}

--- a/tests/executable/cicles/for/outside_of_inner_declaration.c
+++ b/tests/executable/cicles/for/outside_of_inner_declaration.c
@@ -1,0 +1,6 @@
+void main()
+{
+	int i = 0;
+	for (int i = 0; i < 10; i++);
+	assert(i == 0, "Must be 0");
+}


### PR DESCRIPTION
- Реализован разбор конструкции 'for' '(' declaration expression[opt] ';' expression[opt] ')' statement
- Добавлены тесты для этого
- В какой-то момент при переходе reprtab на map потерялся отлов ошибки использования идентификатора за пределами его области видимости - теперь в identab ставятся ITEM_MAX вместо 1
- Добавлен тест на области видимости идентификаторов