### PR TITLE
Кодогенерация LLVM

### DIFF
--- a/libs/compiler/errors.c
+++ b/libs/compiler/errors.c
@@ -600,6 +600,9 @@ void get_error(const error_t num, char *const msg, va_list args)
 		case expected_colon_after_default:
 			sprintf(msg, "после метки УМОЛЧАНИЕ нет :");
 			break;
+		case array_borders_cannot_be_static_dynamic:
+			sprintf(msg, "массив не может иметь статические и динамические границы");
+			break;
 
 		default:
 			sprintf(msg, "неизвестный код ошибки (%i)", num);

--- a/libs/compiler/errors.h
+++ b/libs/compiler/errors.h
@@ -194,6 +194,7 @@ typedef enum ERROR
 	// Codegen errors
 	tables_cannot_be_compressed,
 	transposition_not_possible,
+	array_borders_cannot_be_static_dynamic
 } error_t;
 
 /** Warnings codes */

--- a/libs/compiler/llvmgen.c
+++ b/libs/compiler/llvmgen.c
@@ -1364,8 +1364,9 @@ int encode_to_llvm(const workspace *const ws, universal_io *const io, syntax *co
 	info.answer_reg = 0;
 
 	info.arrays = hash_create(HASH_TABLE_SIZE);
+	
 	const int ret = codegen(&info);
-	hash_clear(&info.arrays);
 
+	hash_clear(&info.arrays);
 	return ret;
 }

--- a/libs/compiler/llvmgen.c
+++ b/libs/compiler/llvmgen.c
@@ -251,21 +251,25 @@ static void operation_to_io(universal_io *const io, const item_t type)
 
 		case PLUSASSR:
 		case PLUSASSRV:
+		case LPLUSR:
 			uni_printf(io, "fadd");
 			break;
 
 		case MINUSASSR:
 		case MINUSASSRV:
+		case LMINUSR:
 			uni_printf(io, "fsub");
 			break;
 
 		case MULTASSR:
 		case MULTASSRV:
+		case LMULTR:
 			uni_printf(io, "fmul");
 			break;
 		
 		case DIVASSR:
 		case DIVASSRV:
+		case LDIVR:
 			uni_printf(io, "fdiv");
 			break;
 	}
@@ -294,11 +298,18 @@ static void to_code_operation_reg_const_double(information *const info, item_t t
 	uni_printf(info->io, " double %%.%" PRIitem ", %f\n", fst, snd);
 }
 
-static void to_code_operation_const_reg(information *const info, item_t type, item_t fst, item_t snd)
+static void to_code_operation_const_reg_i32(information *const info, item_t type, item_t fst, item_t snd)
 {
 	uni_printf(info->io, " %%.%" PRIitem " = ", info->register_num);
 	operation_to_io(info->io, type);
 	uni_printf(info->io, " i32 %" PRIitem ", %%.%" PRIitem "\n", fst, snd);
+}
+
+static void to_code_operation_const_reg_double(information *const info, item_t type, double fst, item_t snd)
+{
+	uni_printf(info->io, " %%.%" PRIitem " = ", info->register_num);
+	operation_to_io(info->io, type);
+	uni_printf(info->io, " double %f, %%.%" PRIitem "\n", fst, snd);
 }
 
 static void to_code_load(information *const info, item_t result, item_t displ, type_t type)
@@ -647,6 +658,7 @@ static void arithmetic_expression(information *const info, node *const nd)
 	const answer_t left_type = info->answer_type;
 	const item_t left_reg = info->answer_reg;
 	const item_t left_const = info->answer_const;
+	const double left_const_double = info->answer_const_double;
 
 	info->variable_location = LFREE;
 	expression(info, nd);
@@ -656,18 +668,49 @@ static void arithmetic_expression(information *const info, node *const nd)
 	const answer_t right_type = info->answer_type;
 	const item_t right_reg = info->answer_reg;
 	const item_t right_const = info->answer_const;
+	const double right_const_double = info->answer_const_double;
+
+	if (is_double(operation_type))
+	{
+		info->answer_value_type = DOUBLE;
+	}
+	else
+	{
+		info->answer_value_type = I32;
+	}
 
 	if (left_type == AREG && right_type == AREG)
 	{
-		to_code_operation_reg_reg(info, operation_type, left_reg, right_reg, I32);
+		if (!is_double(operation_type))
+		{
+			to_code_operation_reg_reg(info, operation_type, left_reg, right_reg, I32);
+		}
+		else // double
+		{
+			to_code_operation_reg_reg(info, operation_type, left_reg, right_reg, DOUBLE);
+		}
 	}
 	else if (left_type == AREG && right_type == ACONST)
 	{
-		to_code_operation_reg_const_i32(info, operation_type, left_reg, right_const);
+		if (!is_double(operation_type))
+		{
+			to_code_operation_reg_const_i32(info, operation_type, left_reg, right_const);
+		}
+		else // double
+		{
+			to_code_operation_reg_const_double(info, operation_type, left_reg, right_const_double);
+		}
 	}
 	else if (left_type == ACONST && right_type == AREG)
 	{
-		to_code_operation_const_reg(info, operation_type, left_const, right_reg);
+		if (!is_double(operation_type))
+		{
+			to_code_operation_const_reg_i32(info, operation_type, left_const, right_reg);
+		}
+		else // double
+		{
+			to_code_operation_const_reg_double(info, operation_type, left_const_double, right_reg);
+		}
 	}
 	else // if (left_type == ACONST && right_type == ACONST)
 	{
@@ -724,11 +767,25 @@ static void arithmetic_expression(information *const info, node *const nd)
 			case LGE:
 				info->answer_const = left_const >= right_const;
 				break;
+
+			case LPLUSR:
+				info->answer_const_double = left_const_double + right_const_double;
+				break;
+			case LMINUSR:
+				info->answer_const_double = left_const_double - right_const_double;
+				break;
+			case LMULTR:
+				info->answer_const_double = left_const_double * right_const_double;
+				break;
+			case LDIVR:
+				info->answer_const_double = left_const_double / right_const_double;
+				break;
 		}
 		return;
 	}
-
+	
 	info->answer_reg = info->register_num++;
+	info->answer_type = AREG;
 }
 
 // Обрабатываются операции инкремента/декремента и постинкремента/постдекремента
@@ -786,7 +843,7 @@ static void unary_operation(information *const info, node *const nd)
 
 			to_code_try_zext_to(info);
 
-			to_code_operation_const_reg(info, UNMINUS, 0, info->answer_reg);
+			to_code_operation_const_reg_i32(info, UNMINUS, 0, info->answer_reg);
 			info->answer_type = AREG;
 			info->answer_reg = info->register_num++;
 		}
@@ -866,10 +923,12 @@ static void binary_operation(information *const info, node *const nd)
 		case LAND:
 		case LEXOR:
 		case LOR:
-		{
+
+		case LPLUSR:
+		case LMINUSR:
+		case LMULTR:
+		case LDIVR:
 			arithmetic_expression(info, nd);
-			info->answer_type = AREG;
-		}
 		break;
 
 
@@ -881,7 +940,10 @@ static void binary_operation(information *const info, node *const nd)
 		case LGE:
 		{
 			arithmetic_expression(info, nd);
-			info->answer_type = ALOGIC;
+			if (info->answer_type == AREG)
+			{
+				info->answer_type = ALOGIC;
+			}
 		}
 		break;
 

--- a/libs/compiler/llvmgen.c
+++ b/libs/compiler/llvmgen.c
@@ -15,7 +15,6 @@
  */
 
 #include "llvmgen.h"
-#include "codes.h"
 #include "errors.h"
 #include "llvmopt.h"
 #include "tree.h"
@@ -1280,7 +1279,6 @@ int encode_to_llvm(const workspace *const ws, universal_io *const io, syntax *co
 	{
 		return -1;
 	}
-	tree_print("new1.txt", &(sx->tree));
 
 	return codegen(io, sx);
 }

--- a/libs/compiler/llvmgen.c
+++ b/libs/compiler/llvmgen.c
@@ -586,6 +586,18 @@ static void unary_operation(information *const info, node *const nd)
 			info->answer_reg = info->register_num++;
 		}
 		break;
+		case LOGNOT:
+		{
+			const item_t old_label_if = info->label_if;
+			const item_t old_label_else = info->label_else;
+
+			node_set_next(nd);
+			expression(info, nd);
+			info->label_if = old_label_else;
+			info->label_else = old_label_if;
+		}
+			break;
+		// TODO: забыл сделать битовое отрицание, нужно доделать
 		default:
 		{
 			node_set_next(nd);
@@ -652,6 +664,7 @@ static void binary_operation(information *const info, node *const nd)
 			break;
 
 // TODO: подумать над объединением LOGOR и LOGAND
+// TODO: c LOGNOT некорректно устанавливаются метки
 		case LOGOR:
 		{
 			const item_t label_next = info->label_num++;
@@ -664,7 +677,7 @@ static void binary_operation(information *const info, node *const nd)
 			// TODO: сделать обработку других ответов
 			if (info->answer_type == ALOGIC)
 			{
-				to_code_conditional_branch(info, info->answer_reg, info->label_if, label_next);
+				to_code_conditional_branch(info, info->answer_reg, info->label_if, info->label_else);
 			}
 
 			to_code_label(info, label_next);
@@ -685,7 +698,7 @@ static void binary_operation(information *const info, node *const nd)
 			// TODO: сделать обработку других ответов
 			if (info->answer_type == ALOGIC)
 			{
-				to_code_conditional_branch(info, info->answer_reg, label_next, info->label_else);
+				to_code_conditional_branch(info, info->answer_reg, info->label_if, info->label_else);
 			}
 
 			to_code_label(info, label_next);
@@ -902,7 +915,7 @@ static void statement(information *const info, node *const nd)
 			// TODO: сделать обработку других ответов
 			if (info->answer_type == ALOGIC)
 			{
-				to_code_conditional_branch(info, info->answer_reg, label_if, label_else);
+				to_code_conditional_branch(info, info->answer_reg, info->label_if, info->label_else);
 			}
 			to_code_label(info, label_if);
 

--- a/libs/compiler/llvmgen.c
+++ b/libs/compiler/llvmgen.c
@@ -632,7 +632,7 @@ static void unary_operation(information *const info, node *const nd)
 			node_set_next(nd);
 			expression(info, nd);
 		}
-			break;
+		break;
 		// TODO: забыл сделать битовое отрицание, нужно доделать
 		default:
 		{

--- a/libs/compiler/llvmgen.c
+++ b/libs/compiler/llvmgen.c
@@ -69,8 +69,9 @@ typedef struct information
 
 	item_t answer_reg;							/**< Регистр с ответом */
 	item_t answer_const;						/**< Константа с ответом */
+	double answer_const_double;					/**< Константа с ответом типа double */
 	answer_t answer_type;						/**< Тип ответа */
-	type_t answer_reg_type;						/**< Тип значения в регистре */
+	type_t answer_value_type;					/**< Тип значения */
 
 	item_t label_true;							/**< Метка перехода при true */
 	item_t label_false;							/**< Метка перехода при false */
@@ -234,9 +235,13 @@ static void to_code_load(information *const info, item_t result, item_t displ, t
 	uni_printf(info->io, "* %%var.%" PRIitem ", align 4\n", displ);
 }
 
-static inline void to_code_store_reg(information *const info, item_t reg, item_t displ)
+static void to_code_store_reg(information *const info, item_t reg, item_t displ, type_t type)
 {
-	uni_printf(info->io, " store i32 %%.%" PRIitem ", i32* %%var.%" PRIitem ", align 4\n", reg, displ);
+	uni_printf(info->io, " store ");
+	type_to_io(info->io, type);
+	uni_printf(info->io, " %%.%" PRIitem ", ", reg);
+	type_to_io(info->io, type);
+	uni_printf(info->io, "* %%var.%" PRIitem ", align 4\n", displ);
 }
 
 static inline void to_code_store_const_i32(information *const info, item_t arg, item_t displ)
@@ -244,9 +249,9 @@ static inline void to_code_store_const_i32(information *const info, item_t arg, 
 	uni_printf(info->io, " store i32 %" PRIitem ", i32* %%var.%" PRIitem ", align 4\n", arg, displ);
 }
 
-static void to_code_store_const_double(information *const info, item_t arg1, item_t arg2, item_t displ)
+static void to_code_store_const_double(information *const info, double arg, item_t displ)
 {
-	uni_printf(info->io, " store double %f, double* %%var.%" PRIitem ", align 4\n", to_double(arg1, arg2), displ);
+	uni_printf(info->io, " store double %f, double* %%var.%" PRIitem ", align 4\n", arg, displ);
 }
 
 static void to_code_try_zext_to(information *const info)
@@ -366,7 +371,7 @@ static void operand(information *const info, node *const nd)
 			to_code_load(info, info->register_num, displ, I32);
 			info->answer_reg = info->register_num++;
 			info->answer_type = AREG;
-			info->answer_reg_type = I32;
+			info->answer_value_type = I32;
 			node_set_next(nd);
 		}
 		break;
@@ -377,7 +382,7 @@ static void operand(information *const info, node *const nd)
 			to_code_load(info, info->register_num, displ, DOUBLE);
 			info->answer_reg = info->register_num++;
 			info->answer_type = AREG;
-			info->answer_reg_type = DOUBLE;
+			info->answer_value_type = DOUBLE;
 			node_set_next(nd);
 		}
 		break;
@@ -394,6 +399,7 @@ static void operand(information *const info, node *const nd)
 			{
 				info->answer_type = ACONST;
 				info->answer_const = num;
+				info->answer_value_type = I32;
 			}
 
 			node_set_next(nd);
@@ -401,14 +407,18 @@ static void operand(information *const info, node *const nd)
 		break;
 		case TConstd:
 		{
+			const double num = to_double(node_get_arg(nd, 0), node_get_arg(nd, 1));
+
 			if (info->variable_location == LMEM)
 			{
-				to_code_store_const_double(info, node_get_arg(nd, 0), node_get_arg(nd, 1), info->request_reg);
+				to_code_store_const_double(info, num, info->request_reg);
 				info->answer_type = AREG;
 			}
 			else
 			{
-				// TODO: обработать этот случай аналогично TConst
+				info->answer_type = ACONST;
+				info->answer_const_double = num;
+				info->answer_value_type = DOUBLE;
 			}
 
 			node_set_next(nd);
@@ -502,7 +512,7 @@ static void assignment_expression(information *const info, node *const nd)
 
 	item_t result = info->answer_reg;
 
-	if (assignment_type != ASS && assignment_type != ASSV)
+	if (assignment_type != ASS && assignment_type != ASSV && assignment_type != ASSR && assignment_type != ASSRV)
 	{
 		to_code_load(info, info->register_num, displ, I32);
 		info->register_num++;
@@ -519,13 +529,20 @@ static void assignment_expression(information *const info, node *const nd)
 		result = info->register_num++;
 	}
 
-	if (info->answer_type == AREG || (assignment_type != ASS && assignment_type != ASSV))
+	if (info->answer_type == AREG || (assignment_type != ASS && assignment_type != ASSV && assignment_type != ASSR && assignment_type != ASSRV))
 	{
-		to_code_store_reg(info, result, displ);
+		to_code_store_reg(info, result, displ, info->answer_value_type); // TODO: правильно ли тут с типом, надо потестить
 	}
 	else // ACONST && =
 	{
-		to_code_store_const_i32(info, info->answer_const, displ);
+		if (info->answer_value_type == I32)
+		{
+			to_code_store_const_i32(info, info->answer_const, displ);
+		}
+		else // if (info->answer_value_type == DOUBLE)
+		{
+			to_code_store_const_double(info, info->answer_const_double, displ);
+		}
 	}
 }
 
@@ -654,7 +671,7 @@ static void inc_dec_expression(information *const info, node *const nd)
 			break;
 	}
 
-	to_code_store_reg(info, info->register_num, displ);
+	to_code_store_reg(info, info->register_num, displ, I32);
 	info->register_num++;
 }
 
@@ -734,6 +751,9 @@ static void binary_operation(information *const info, node *const nd)
 		case EXORASSV:
 		case ORASS:
 		case ORASSV:
+
+		case ASSR:
+		case ASSRV:
 			assignment_expression(info, nd);
 			break;
 
@@ -1209,7 +1229,7 @@ static void statement(information *const info, node *const nd)
 				info->variable_location = LREG;
 				expression(info, nd);
 				args[i] = info->answer_reg;
-				args_type[i] = info->answer_reg_type;
+				args_type[i] = info->answer_value_type;
 			}
 
 			uni_printf(info->io, " %%.%" PRIitem " = call i32 (i8*, ...) @printf(i8* getelementptr inbounds "
@@ -1363,7 +1383,7 @@ static int codegen(universal_io *const io, syntax *const sx)
 	info.variable_location = LREG;
 	info.request_reg = 0;
 	info.answer_reg = 0;
-	info.answer_reg_type = I32;
+	info.answer_value_type = I32;
 
 	node root = node_get_root(&sx->tree);
 	int was_stack_functions = 0;

--- a/libs/compiler/llvmgen.c
+++ b/libs/compiler/llvmgen.c
@@ -210,9 +210,16 @@ static inline void to_code_store_const(information *const info, item_t arg, item
 	uni_printf(info->io, " store i32 %" PRIitem ", i32* %%var.%" PRIitem ", align 4\n", arg, displ);
 }
 
-static inline void to_code_zext_to(information *const info, item_t arg)
+static inline void to_code_try_zext_to(information *const info)
 {
-	uni_printf(info->io, " %%.%" PRIitem " = zext i1 %%.%" PRIitem " to i32\n", info->register_num, arg);
+	if (info->answer_type != ALOGIC)
+	{
+		return;
+	}
+
+	uni_printf(info->io, " %%.%" PRIitem " = zext i1 %%.%" PRIitem " to i32\n", info->register_num, info->answer_reg);
+	info->answer_type = AREG;
+	info->answer_reg = info->register_num++;
 }
 
 static inline void to_code_label(information *const info, item_t label_num)
@@ -427,12 +434,7 @@ static void assignment_expression(information *const info, node *const nd)
 	info->variable_location = LFREE;
 	expression(info, nd);
 
-	if (info->answer_type == ALOGIC)
-	{
-		to_code_zext_to(info, info->answer_reg);
-		info->answer_type = AREG;
-		info->answer_reg = info->register_num++;
-	}
+	to_code_try_zext_to(info);
 
 	item_t result = info->answer_reg;
 
@@ -471,12 +473,7 @@ static void arithmetic_expression(information *const info, node *const nd)
 	info->variable_location = LFREE;
 	expression(info, nd);
 
-	if (info->answer_type == ALOGIC)
-	{
-		to_code_zext_to(info, info->answer_reg);
-		info->answer_type = AREG;
-		info->answer_reg = info->register_num++;
-	}
+	to_code_try_zext_to(info);
 
 	const answer_t left_type = info->answer_type;
 	const item_t left_reg = info->answer_reg;
@@ -485,12 +482,7 @@ static void arithmetic_expression(information *const info, node *const nd)
 	info->variable_location = LFREE;
 	expression(info, nd);
 
-	if (info->answer_type == ALOGIC)
-	{
-		to_code_zext_to(info, info->answer_reg);
-		info->answer_type = AREG;
-		info->answer_reg = info->register_num++;
-	}
+	to_code_try_zext_to(info);
 
 	const answer_t right_type = info->answer_type;
 	const item_t right_reg = info->answer_reg;
@@ -560,12 +552,7 @@ static void logic_expression(information *const info, node *const nd)
 	info->variable_location = LFREE;
 	expression(info, nd);
 
-	if (info->answer_type == ALOGIC)
-	{
-		to_code_zext_to(info, info->answer_reg);
-		info->answer_type = AREG;
-		info->answer_reg = info->register_num++;
-	}
+	to_code_try_zext_to(info);
 
 	const answer_t left_type = info->answer_type;
 	const item_t left_reg = info->answer_reg;
@@ -574,12 +561,7 @@ static void logic_expression(information *const info, node *const nd)
 	info->variable_location = LFREE;
 	expression(info, nd);
 
-	if (info->answer_type == ALOGIC)
-	{
-		to_code_zext_to(info, info->answer_reg);
-		info->answer_type = AREG;
-		info->answer_reg = info->register_num++;
-	}
+	to_code_try_zext_to(info);
 
 	const answer_t right_type = info->answer_type;
 	const item_t right_reg = info->answer_reg;
@@ -682,11 +664,7 @@ static void unary_operation(information *const info, node *const nd)
 			info->variable_location = LREG;
 			expression(info, nd);
 
-			if (info->answer_type == ALOGIC)
-			{
-				to_code_zext_to(info, info->answer_reg);
-				info->answer_reg = info->register_num++;
-			}
+			to_code_try_zext_to(info);
 
 			to_code_operation_const_reg(info, UNMINUS, 0, info->answer_reg);
 			info->answer_type = AREG;

--- a/libs/compiler/llvmgen.c
+++ b/libs/compiler/llvmgen.c
@@ -15,7 +15,6 @@
  */
 
 #include "llvmgen.h"
-#include "codes.h"
 #include "errors.h"
 #include "llvmopt.h"
 #include "tree.h"
@@ -309,7 +308,7 @@ static void operand(information *const info, node *const nd)
 			}
 
 			const size_t ref_ident = (size_t)node_get_arg(nd, 0);
-			const item_t func_type = mode_get(info->sx, ident_get_mode(info->sx, ref_ident) + 1);
+			const item_t func_type = mode_get(info->sx, (size_t)ident_get_mode(info->sx, ref_ident) + 1);
 
 			node_set_next(nd); // TCall2
 			if (func_type == LVOID)
@@ -1271,7 +1270,7 @@ static int codegen(universal_io *const io, syntax *const sx)
 			case TFuncdef:
 			{
 				const size_t ref_ident = (size_t)node_get_arg(&root, 0);
-				const item_t func_type = mode_get(info.sx, ident_get_mode(info.sx, ref_ident) + 1);
+				const item_t func_type = mode_get(info.sx, (size_t)ident_get_mode(info.sx, ref_ident) + 1);
 
 				if (ident_get_prev(info.sx, ref_ident) == LMAIN)
 				{
@@ -1319,7 +1318,6 @@ int encode_to_llvm(const workspace *const ws, universal_io *const io, syntax *co
 	{
 		return -1;
 	}
-	tree_print("new1.txt", &(sx->tree));
 
 	return codegen(io, sx);
 }

--- a/libs/compiler/llvmgen.c
+++ b/libs/compiler/llvmgen.c
@@ -15,6 +15,7 @@
  */
 
 #include "llvmgen.h"
+#include "codes.h"
 #include "errors.h"
 #include "llvmopt.h"
 #include "tree.h"
@@ -1431,6 +1432,7 @@ int encode_to_llvm(const workspace *const ws, universal_io *const io, syntax *co
 	{
 		return -1;
 	}
+	tree_print("new1.txt", &(sx->tree));
 
 	return codegen(io, sx);
 }

--- a/libs/compiler/llvmgen.c
+++ b/libs/compiler/llvmgen.c
@@ -137,25 +137,6 @@ static int is_double(const item_t operation)
 		case LMINUSR:
 		case LMULTR:
 		case LDIVR:
-
-		case POSTINCR:
-		case POSTDECR:
-		case INCR:
-		case DECR:
-		case POSTINCATR:
-		case POSTDECATR:
-		case INCATR:
-		case DECATR:
-		case POSTINCRV:
-		case POSTDECRV:
-		case INCRV:
-		case DECRV:
-		case POSTINCATRV:
-		case POSTDECATRV:
-		case INCATRV:
-		case DECATRV:
-
-		case UNMINUSR:
 			return 1;
 	
 		default:
@@ -269,20 +250,12 @@ static void operation_to_io(universal_io *const io, const item_t type)
 			uni_printf(io, "icmp sge");
 			break;
 
-		case INCR:
-		case INCRV:
-		case POSTINCR:
-		case POSTINCRV:
 		case PLUSASSR:
 		case PLUSASSRV:
 		case LPLUSR:
 			uni_printf(io, "fadd");
 			break;
 
-		case DECR:
-		case DECRV:
-		case POSTDECR:
-		case POSTDECRV:
 		case MINUSASSR:
 		case MINUSASSRV:
 		case LMINUSR:
@@ -825,16 +798,7 @@ static void inc_dec_expression(information *const info, node *const nd)
 	node_set_next(nd);
 	node_set_next(nd); // TIdent
 
-	if (is_double(operation_type))
-	{
-		info->answer_value_type = DOUBLE;
-	}
-	else
-	{
-		info->answer_value_type = I32;
-	}
-
-	to_code_load(info, info->register_num, displ, info->answer_value_type);
+	to_code_load(info, info->register_num, displ, I32);
 	info->answer_type = AREG;
 	info->answer_reg = info->register_num++;
 	
@@ -851,21 +815,9 @@ static void inc_dec_expression(information *const info, node *const nd)
 		case POSTDECV:
 			to_code_operation_reg_const_i32(info, operation_type, info->register_num - 1, 1);
 			break;
-
-		case INCR:
-		case INCRV:
-		case DECR:
-		case DECRV:
-			info->answer_reg = info->register_num;
-		case POSTINCR:
-		case POSTINCRV:
-		case POSTDECR:
-		case POSTDECRV:
-			to_code_operation_reg_const_double(info, operation_type, info->register_num - 1, 1.0);
-			break;
 	}
 
-	to_code_store_reg(info, info->register_num, displ, info->answer_value_type);
+	to_code_store_reg(info, info->register_num, displ, I32);
 	info->register_num++;
 }
 
@@ -881,15 +833,6 @@ static void unary_operation(information *const info, node *const nd)
 		case INCV:
 		case DEC:
 		case DECV:
-
-		case POSTINCR:
-		case POSTINCRV:
-		case POSTDECR:
-		case POSTDECRV:
-		case INCR:
-		case INCRV:
-		case DECR:
-		case DECRV:
 			inc_dec_expression(info, nd);
 			break;
 		case UNMINUS:

--- a/libs/compiler/llvmgen.c
+++ b/libs/compiler/llvmgen.c
@@ -15,6 +15,7 @@
  */
 
 #include "llvmgen.h"
+#include "codes.h"
 #include "errors.h"
 #include "llvmopt.h"
 #include "tree.h"
@@ -1109,10 +1110,14 @@ static void statement(information *const info, node *const nd)
 			node_set_next(nd);
 			info->variable_location = LREG;
 			expression(info, nd);
-			// TODO: добавить обработку других ответов
+			// TODO: добавить обработку других ответов (ALOGIC)
 			if (info->answer_type == ACONST)
 			{
 				uni_printf(info->io, " ret i32 %" PRIitem "\n", info->answer_const);
+			}
+			else if (info->answer_type == AREG)
+			{
+				uni_printf(info->io, " ret i32 %%.%" PRIitem "\n", info->answer_reg);
 			}
 			node_set_next(nd); // TReturnvoid
 		}
@@ -1314,6 +1319,7 @@ int encode_to_llvm(const workspace *const ws, universal_io *const io, syntax *co
 	{
 		return -1;
 	}
+	tree_print("new1.txt", &(sx->tree));
 
 	return codegen(io, sx);
 }

--- a/libs/compiler/llvmgen.c
+++ b/libs/compiler/llvmgen.c
@@ -40,7 +40,7 @@ typedef enum LOCATION
 	LFREE,								/**< Свободный запрос значения */
 } location_t;
 
-// TODO: за типом ответа пока следится только в TIdenttoval и TIdenttovald, а надо везде
+// TODO: надо везде следить за типом
 typedef enum TYPES
 {
 	I32,								/**< int */
@@ -97,6 +97,51 @@ static double to_double(const int64_t fst, const int64_t snd)
 	memcpy(&numdouble, &num, sizeof(double));
 	
 	return numdouble;
+}
+// TODO: по-хорошему, подобное Илья должен был сделать и не в рамках кодогенератора, надо бы ему напомнить
+static int is_double(const item_t operation)
+{
+	switch (operation)
+	{
+		case ASSR:
+		case PLUSASSR:
+		case MINUSASSR:
+		case MULTASSR:
+		case DIVASSR:
+
+		case ASSATR:
+		case PLUSASSATR:
+		case MINUSASSATR:
+		case MULTASSATR:
+		case DIVASSATR:
+
+		case ASSRV:
+		case PLUSASSRV:
+		case MINUSASSRV:
+		case MULTASSRV:
+		case DIVASSRV:
+
+		case ASSATRV:
+		case PLUSASSATRV:
+		case MINUSASSATRV:
+		case MULTASSATRV:
+		case DIVASSATRV:
+
+		case EQEQR:
+		case NOTEQR:
+		case LLTR:
+		case LGTR:
+		case LLER:
+		case LGER:
+		case LPLUSR:
+		case LMINUSR:
+		case LMULTR:
+		case LDIVR:
+			return 1;
+	
+		default:
+			return 0;
+	}
 }
 
 static void type_to_io(universal_io *const io, const type_t type)
@@ -184,6 +229,7 @@ static void operation_to_io(universal_io *const io, const item_t type)
 		case LOR:
 			uni_printf(io, "or");
 			break;
+
 		case EQEQ:
 			uni_printf(io, "icmp eq");
 			break;
@@ -202,21 +248,50 @@ static void operation_to_io(universal_io *const io, const item_t type)
 		case LGE:
 			uni_printf(io, "icmp sge");
 			break;
+
+		case PLUSASSR:
+		case PLUSASSRV:
+			uni_printf(io, "fadd");
+			break;
+
+		case MINUSASSR:
+		case MINUSASSRV:
+			uni_printf(io, "fsub");
+			break;
+
+		case MULTASSR:
+		case MULTASSRV:
+			uni_printf(io, "fmul");
+			break;
+		
+		case DIVASSR:
+		case DIVASSRV:
+			uni_printf(io, "fdiv");
+			break;
 	}
 }
 
-static void to_code_operation_reg_reg(information *const info, item_t type, item_t fst, item_t snd)
+static void to_code_operation_reg_reg(information *const info, item_t operation_type, item_t fst, item_t snd, type_t type)
 {
 	uni_printf(info->io, " %%.%" PRIitem " = ", info->register_num);
-	operation_to_io(info->io, type);
-	uni_printf(info->io, " i32 %%.%" PRIitem ", %%.%" PRIitem "\n", fst, snd);
+	operation_to_io(info->io, operation_type);
+	uni_printf(info->io, " ");
+	type_to_io(info->io, type);
+	uni_printf(info->io, " %%.%" PRIitem ", %%.%" PRIitem "\n", fst, snd);
 }
 
-static void to_code_operation_reg_const(information *const info, item_t type, item_t fst, item_t snd)
+static void to_code_operation_reg_const_i32(information *const info, item_t type, item_t fst, item_t snd)
 {
 	uni_printf(info->io, " %%.%" PRIitem " = ", info->register_num);
 	operation_to_io(info->io, type);
 	uni_printf(info->io, " i32 %%.%" PRIitem ", %" PRIitem "\n", fst, snd);
+}
+
+static void to_code_operation_reg_const_double(information *const info, item_t type, item_t fst, double snd)
+{
+	uni_printf(info->io, " %%.%" PRIitem " = ", info->register_num);
+	operation_to_io(info->io, type);
+	uni_printf(info->io, " double %%.%" PRIitem ", %f\n", fst, snd);
 }
 
 static void to_code_operation_const_reg(information *const info, item_t type, item_t fst, item_t snd)
@@ -340,7 +415,7 @@ static void check_type_and_branch(information *const info)
 			break;
 		case AREG:
 		{
-			to_code_operation_reg_const(info, NOTEQ, info->answer_reg, 0);
+			to_code_operation_reg_const_i32(info, NOTEQ, info->answer_reg, 0);
 			info->answer_reg = info->register_num++;
 		}
 		case ALOGIC:
@@ -496,7 +571,8 @@ static void operand(information *const info, node *const nd)
 			break;
 	}
 }
-
+// TODO: сейчас тут зависимость по типу от типа выражения справа
+// а если слева double, а справа int? или обработка widen всё исправит? надо потестить
 static void assignment_expression(information *const info, node *const nd)
 {
 	const item_t displ = node_get_arg(nd, 0);
@@ -514,16 +590,28 @@ static void assignment_expression(information *const info, node *const nd)
 
 	if (assignment_type != ASS && assignment_type != ASSV && assignment_type != ASSR && assignment_type != ASSRV)
 	{
-		to_code_load(info, info->register_num, displ, I32);
+		if (is_double(assignment_type))
+		{
+			to_code_load(info, info->register_num, displ, DOUBLE);
+		}
+		else
+		{
+			to_code_load(info, info->register_num, displ, I32);
+		}
+		
 		info->register_num++;
 
 		if (info->answer_type == AREG)
 		{
-			to_code_operation_reg_reg(info, assignment_type, info->register_num - 1, info->answer_reg);
+			to_code_operation_reg_reg(info, assignment_type, info->register_num - 1, info->answer_reg, info->answer_value_type);
 		}
-		else // ACONST
+		else if (info->answer_value_type == I32)// ACONST
 		{
-			to_code_operation_reg_const(info, assignment_type, info->register_num - 1, info->answer_const);
+			to_code_operation_reg_const_i32(info, assignment_type, info->register_num - 1, info->answer_const);
+		}
+		else
+		{
+			to_code_operation_reg_const_double(info, assignment_type, info->register_num - 1, info->answer_const_double);
 		}
 			
 		result = info->register_num++;
@@ -531,7 +619,7 @@ static void assignment_expression(information *const info, node *const nd)
 
 	if (info->answer_type == AREG || (assignment_type != ASS && assignment_type != ASSV && assignment_type != ASSR && assignment_type != ASSRV))
 	{
-		to_code_store_reg(info, result, displ, info->answer_value_type); // TODO: правильно ли тут с типом, надо потестить
+		to_code_store_reg(info, result, displ, info->answer_value_type);
 	}
 	else // ACONST && =
 	{
@@ -571,11 +659,11 @@ static void arithmetic_expression(information *const info, node *const nd)
 
 	if (left_type == AREG && right_type == AREG)
 	{
-		to_code_operation_reg_reg(info, operation_type, left_reg, right_reg);
+		to_code_operation_reg_reg(info, operation_type, left_reg, right_reg, I32);
 	}
 	else if (left_type == AREG && right_type == ACONST)
 	{
-		to_code_operation_reg_const(info, operation_type, left_reg, right_const);
+		to_code_operation_reg_const_i32(info, operation_type, left_reg, right_const);
 	}
 	else if (left_type == ACONST && right_type == AREG)
 	{
@@ -667,7 +755,7 @@ static void inc_dec_expression(information *const info, node *const nd)
 		case POSTINCV:
 		case POSTDEC:
 		case POSTDECV:
-			to_code_operation_reg_const(info, operation_type, info->register_num - 1, 1);
+			to_code_operation_reg_const_i32(info, operation_type, info->register_num - 1, 1);
 			break;
 	}
 
@@ -754,6 +842,15 @@ static void binary_operation(information *const info, node *const nd)
 
 		case ASSR:
 		case ASSRV:
+
+		case PLUSASSR:
+		case PLUSASSRV:
+		case MINUSASSR:
+		case MINUSASSRV:
+		case MULTASSR:
+		case MULTASSRV:
+		case DIVASSR:
+		case DIVASSRV:
 			assignment_expression(info, nd);
 			break;
 

--- a/libs/compiler/llvmgen.c
+++ b/libs/compiler/llvmgen.c
@@ -1364,7 +1364,6 @@ int encode_to_llvm(const workspace *const ws, universal_io *const io, syntax *co
 	info.answer_reg = 0;
 
 	info.arrays = hash_create(HASH_TABLE_SIZE);
-
 	const int ret = codegen(&info);
 	hash_clear(&info.arrays);
 

--- a/libs/compiler/llvmgen.c
+++ b/libs/compiler/llvmgen.c
@@ -1068,7 +1068,7 @@ static void binary_operation(information *const info, node *const nd)
 		case LGER:
 		{
 			integral_expression(info, nd, ALOGIC);
-
+			
 			if (info->answer_type == ACONST)
 			{
 				info->answer_value_type = I32;

--- a/libs/compiler/llvmgen.c
+++ b/libs/compiler/llvmgen.c
@@ -221,6 +221,7 @@ static void operation_to_io(universal_io *const io, const item_t type)
 		case EXORASS:
 		case EXORASSV:
 		case LEXOR:
+		case LNOT:
 			uni_printf(io, "xor");
 			break;
 
@@ -835,7 +836,9 @@ static void unary_operation(information *const info, node *const nd)
 			inc_dec_expression(info, nd);
 			break;
 		case UNMINUS:
+		case LNOT:
 		{
+			const item_t operation_type = node_get_type(nd);
 			node_set_next(nd);
 
 			info->variable_location = LREG;
@@ -843,7 +846,15 @@ static void unary_operation(information *const info, node *const nd)
 
 			to_code_try_zext_to(info);
 
-			to_code_operation_const_reg_i32(info, UNMINUS, 0, info->answer_reg);
+			if (operation_type == UNMINUS)
+			{
+				to_code_operation_const_reg_i32(info, UNMINUS, 0, info->answer_reg);
+			}
+			else // LNOT
+			{
+				to_code_operation_reg_const_i32(info, LNOT, info->answer_reg, -1);
+			}
+
 			info->answer_type = AREG;
 			info->answer_reg = info->register_num++;
 		}
@@ -858,7 +869,6 @@ static void unary_operation(information *const info, node *const nd)
 			expression(info, nd);
 		}
 			break;
-		// TODO: забыл сделать битовое отрицание, нужно доделать
 		default:
 		{
 			node_set_next(nd);

--- a/libs/compiler/llvmgen.c
+++ b/libs/compiler/llvmgen.c
@@ -286,7 +286,6 @@ static void operation_to_io(universal_io *const io, const item_t type)
 		case MINUSASSR:
 		case MINUSASSRV:
 		case LMINUSR:
-		case UNMINUSR:
 			uni_printf(io, "fsub");
 			break;
 
@@ -300,25 +299,6 @@ static void operation_to_io(universal_io *const io, const item_t type)
 		case DIVASSRV:
 		case LDIVR:
 			uni_printf(io, "fdiv");
-			break;
-
-		case EQEQR:
-			uni_printf(io, "fcmp oeq");
-			break;
-		case NOTEQR:
-			uni_printf(io, "fcmp one");
-			break;
-		case LLTR:
-			uni_printf(io, "fcmp olt");
-			break;
-		case LGTR:
-			uni_printf(io, "fcmp ogt");
-			break;
-		case LLER:
-			uni_printf(io, "fcmp ole");
-			break;
-		case LGER:
-			uni_printf(io, "fcmp oge");
 			break;
 	}
 }
@@ -416,7 +396,7 @@ static inline void to_code_conditional_branch(information *const info, item_t re
 		reg, label_true, label_false);
 }
 
-static void to_code_alloc_array_static(information *const info, item_t id, type_t type)
+static void to_code_alloc_array_static(information *const info, item_t id)
 {
 	uni_printf(info->io, " %%arr.%" PRIitem " = alloca ", id);
 
@@ -424,8 +404,7 @@ static void to_code_alloc_array_static(information *const info, item_t id, type_
 	{
 		uni_printf(info->io, "[%" PRIitem " x ", info->arrays_info[id].borders[i]);
 	}
-
-	type_to_io(info->io, type);
+	uni_printf(info->io, "i32");
 
 	for (item_t i = 0; i < info->arrays_info[id].dimention; i++)
 	{
@@ -596,14 +575,6 @@ static void operand(information *const info, node *const nd)
 			{
 				uni_printf(info->io, " %%.%" PRIitem " = call i32 @func%zi(", info->register_num, ref_ident);
 				info->answer_type = AREG;
-				info->answer_value_type = I32;
-				info->answer_reg = info->register_num++;
-			}
-			else if (func_type == mode_float)
-			{
-				uni_printf(info->io, " %%.%" PRIitem " = call double @func%zi(", info->register_num, ref_ident);
-				info->answer_type = AREG;
-				info->answer_value_type = DOUBLE;
 				info->answer_reg = info->register_num++;
 			}
 			// тут будет ещё перечисление аргументов
@@ -837,25 +808,6 @@ static void arithmetic_expression(information *const info, node *const nd)
 			case LDIVR:
 				info->answer_const_double = left_const_double / right_const_double;
 				break;
-
-			case EQEQR:
-				info->answer_const = left_const_double == right_const_double;
-				break;
-			case NOTEQR:
-				info->answer_const = left_const_double != right_const_double;
-				break;
-			case LLTR:
-				info->answer_const = left_const_double < right_const_double;
-				break;
-			case LGTR:
-				info->answer_const = left_const_double > right_const_double;
-				break;
-			case LLER:
-				info->answer_const = left_const_double <= right_const_double;
-				break;
-			case LGER:
-				info->answer_const = left_const_double >= right_const_double;
-				break;
 		}
 		return;
 	}
@@ -942,7 +894,6 @@ static void unary_operation(information *const info, node *const nd)
 			break;
 		case UNMINUS:
 		case LNOT:
-		case UNMINUSR:
 		{
 			const item_t operation_type = node_get_type(nd);
 			node_set_next(nd);
@@ -952,19 +903,13 @@ static void unary_operation(information *const info, node *const nd)
 
 			to_code_try_zext_to(info);
 
-			info->answer_value_type = I32;
 			if (operation_type == UNMINUS)
 			{
 				to_code_operation_const_reg_i32(info, UNMINUS, 0, info->answer_reg);
 			}
-			else if (operation_type == LNOT) 
+			else // LNOT
 			{
 				to_code_operation_reg_const_i32(info, LNOT, info->answer_reg, -1);
-			}
-			else // UNMINUSR
-			{
-				to_code_operation_const_reg_double(info, UNMINUSR, 0, info->answer_reg);
-				info->answer_value_type = DOUBLE;
 			}
 
 			info->answer_type = AREG;
@@ -1060,22 +1005,11 @@ static void binary_operation(information *const info, node *const nd)
 		case LGT:
 		case LLE:
 		case LGE:
-
-		case EQEQR:
-		case NOTEQR:
-		case LLTR:
-		case LGTR:
-		case LLER:
-		case LGER:
 		{
 			arithmetic_expression(info, nd);
 			if (info->answer_type == AREG)
 			{
 				info->answer_type = ALOGIC;
-			}
-			else // ACONST 
-			{
-				info->answer_value_type = I32;
 			}
 		}
 		break;
@@ -1487,19 +1421,13 @@ static void statement(information *const info, node *const nd)
 			expression(info, nd);
 
 			// TODO: добавить обработку других ответов (ALOGIC)
-			if (info->answer_type == ACONST && info->answer_value_type == I32)
+			if (info->answer_type == ACONST)
 			{
 				uni_printf(info->io, " ret i32 %" PRIitem "\n", info->answer_const);
 			}
-			else if (info->answer_type == ACONST && info->answer_value_type == DOUBLE)
-			{
-				uni_printf(info->io, " ret double %f\n", info->answer_const_double);
-			}
 			else if (info->answer_type == AREG)
 			{
-				uni_printf(info->io, " ret ");
-				type_to_io(info->io, info->answer_value_type);
-				uni_printf(info->io, " %%.%" PRIitem "\n", info->answer_reg);
+				uni_printf(info->io, " ret i32 %%.%" PRIitem "\n", info->answer_reg);
 			}
 			node_set_next(nd); // TReturnvoid
 		}
@@ -1636,19 +1564,9 @@ static void block(information *const info, node *const nd)
 				else // массивы
 				{
 					info->arrays_info[displ] = info->current_array_info;
-
-					if (elem_type == mode_integer)
-					{
-						info->answer_value_type = I32;
-					}
-					else if (elem_type == mode_float)
-					{
-						info->answer_value_type = DOUBLE;
-					}
-
 					if (info->current_array_info.is_static)
 					{
-						to_code_alloc_array_static(info, displ, info->answer_value_type);
+						to_code_alloc_array_static(info, displ);
 					}
 					else
 					{
@@ -1656,7 +1574,6 @@ static void block(information *const info, node *const nd)
 						{
 							to_code_stack_save(info);
 						}
-						// TODO: сделать объявление массивов double, после вырезки
 						to_code_alloc_array_dynamic(info, displ);
 						info->was_dynamic = 1;
 					}	
@@ -1717,10 +1634,6 @@ static int codegen(universal_io *const io, syntax *const sx)
 				else if (func_type == mode_integer)
 				{
 					uni_printf(info.io, "define i32 @func%zi(", ref_ident);
-				}
-				else if (func_type == mode_float)
-				{
-					uni_printf(info.io, "define double @func%zi(", ref_ident);
 				}
 				uni_printf(info.io, ") {\n");
 

--- a/libs/compiler/llvmgen.c
+++ b/libs/compiler/llvmgen.c
@@ -221,7 +221,6 @@ static void operation_to_io(universal_io *const io, const item_t type)
 		case EXORASS:
 		case EXORASSV:
 		case LEXOR:
-		case LNOT:
 			uni_printf(io, "xor");
 			break;
 
@@ -836,9 +835,7 @@ static void unary_operation(information *const info, node *const nd)
 			inc_dec_expression(info, nd);
 			break;
 		case UNMINUS:
-		case LNOT:
 		{
-			const item_t operation_type = node_get_type(nd);
 			node_set_next(nd);
 
 			info->variable_location = LREG;
@@ -846,15 +843,7 @@ static void unary_operation(information *const info, node *const nd)
 
 			to_code_try_zext_to(info);
 
-			if (operation_type == UNMINUS)
-			{
-				to_code_operation_const_reg_i32(info, UNMINUS, 0, info->answer_reg);
-			}
-			else // LNOT
-			{
-				to_code_operation_reg_const_i32(info, LNOT, info->answer_reg, -1);
-			}
-
+			to_code_operation_const_reg_i32(info, UNMINUS, 0, info->answer_reg);
 			info->answer_type = AREG;
 			info->answer_reg = info->register_num++;
 		}
@@ -869,6 +858,7 @@ static void unary_operation(information *const info, node *const nd)
 			expression(info, nd);
 		}
 			break;
+		// TODO: забыл сделать битовое отрицание, нужно доделать
 		default:
 		{
 			node_set_next(nd);

--- a/libs/compiler/llvmgen.c
+++ b/libs/compiler/llvmgen.c
@@ -652,7 +652,6 @@ static void binary_operation(information *const info, node *const nd)
 			break;
 
 // TODO: подумать над объединением LOGOR и LOGAND
-// TODO: рассмотреть более сложные условия: потестировать LOGOR и сделать LOGAND
 		case LOGOR:
 		{
 			const item_t label_next = info->label_num++;
@@ -671,18 +670,15 @@ static void binary_operation(information *const info, node *const nd)
 			to_code_label(info, label_next);
 			info->label_else = old_label_else;
 
-			if (node_get_type(nd) == ADLOGOR)
-			{
-				node_set_next(nd);
-			}
-
 			expression(info, nd);
 		}
 		break;
 		case LOGAND:
 		{
 			const item_t label_next = info->label_num++;
+			const item_t old_label_if = info->label_if;
 
+			info->label_if = label_next;
 			node_set_next(nd);
 			expression(info, nd);
 
@@ -691,12 +687,9 @@ static void binary_operation(information *const info, node *const nd)
 			{
 				to_code_conditional_branch(info, info->answer_reg, label_next, info->label_else);
 			}
-			to_code_label(info, label_next);
 
-			if (node_get_type(nd) == ADLOGAND)
-			{
-				node_set_next(nd);
-			}
+			to_code_label(info, label_next);
+			info->label_if = old_label_if;
 
 			expression(info, nd);
 		}

--- a/libs/compiler/llvmgen.c
+++ b/libs/compiler/llvmgen.c
@@ -311,11 +311,11 @@ static void operand(information *const info, node *const nd)
 			const item_t func_type = mode_get(info->sx, (size_t)ident_get_mode(info->sx, ref_ident) + 1);
 
 			node_set_next(nd); // TCall2
-			if (func_type == LVOID)
+			if (func_type == mode_void)
 			{
 				uni_printf(info->io, " call void @func%zi(", ref_ident);
 			}
-			else if (func_type == LINT)
+			else if (func_type == mode_integer)
 			{
 				uni_printf(info->io, " %%.%" PRIitem " = call i32 @func%zi(", info->register_num, ref_ident);
 				info->answer_type = AREG;
@@ -1218,7 +1218,7 @@ static void block(information *const info, node *const nd, int mode)
 
 				if (N == 0) // обычная переменная int a; или struct point p;
 				{
-					if (elem_type == LINT)
+					if (elem_type == mode_integer)
 					{
 						uni_printf(info->io, " %%var.%" PRIitem " = alloca i32, align 4\n", displ);
 						info->variable_location = LMEM;
@@ -1276,11 +1276,11 @@ static int codegen(universal_io *const io, syntax *const sx)
 				{
 					uni_printf(info.io, "define i32 @main(");
 				}
-				else if (func_type == LVOID)
+				else if (func_type == mode_void)
 				{
 					uni_printf(info.io, "define void @func%zi(", ref_ident);
 				}
-				else if (func_type == LINT)
+				else if (func_type == mode_integer)
 				{
 					uni_printf(info.io, "define i32 @func%zi(", ref_ident);
 				}

--- a/libs/compiler/llvmgen.c
+++ b/libs/compiler/llvmgen.c
@@ -244,7 +244,7 @@ static void to_code_alloc_array_static(information *const info, const item_t id)
 
 	for (item_t i = 0; i < hash_get(&(info->arrays_info), id, DIMENSION); i++)
 	{
-		uni_printf(info->io, "[%" PRIitem " x ", hash_get(&(info->arrays_info), id, BORDERS + i));
+		uni_printf(info->io, "[%" PRIitem " x ", hash_get(&(info->arrays_info), id, BORDERS + (size_t)i));
 	}
 	uni_printf(info->io, "i32");
 
@@ -263,7 +263,7 @@ static void to_code_alloc_array_dynamic(information *const info, const item_t id
 	for (item_t i = 1; i < hash_get(&(info->arrays_info), id, DIMENSION); i++)
 	{
 		uni_printf(info->io, " %%.%" PRIitem " = mul nuw i32 %%.%" PRIitem ", %%.%" PRIitem "\n", 
-			info->register_num, to_alloc, hash_get(&(info->arrays_info), id, BORDERS + i));
+			info->register_num, to_alloc, hash_get(&(info->arrays_info), id, BORDERS + (size_t)i));
 		to_alloc = info->register_num++;
 	}
 	uni_printf(info->io, " %%dynarr.%" PRIitem " = alloca i32, i32 %%.%" PRIitem ", align 4\n", id, to_alloc);	

--- a/libs/compiler/llvmgen.c
+++ b/libs/compiler/llvmgen.c
@@ -15,7 +15,6 @@
  */
 
 #include "llvmgen.h"
-#include "codes.h"
 #include "errors.h"
 #include "llvmopt.h"
 #include "tree.h"
@@ -1432,7 +1431,6 @@ int encode_to_llvm(const workspace *const ws, universal_io *const io, syntax *co
 	{
 		return -1;
 	}
-	tree_print("new1.txt", &(sx->tree));
 
 	return codegen(io, sx);
 }

--- a/libs/compiler/llvmgen.c
+++ b/libs/compiler/llvmgen.c
@@ -137,6 +137,25 @@ static int is_double(const item_t operation)
 		case LMINUSR:
 		case LMULTR:
 		case LDIVR:
+
+		case POSTINCR:
+		case POSTDECR:
+		case INCR:
+		case DECR:
+		case POSTINCATR:
+		case POSTDECATR:
+		case INCATR:
+		case DECATR:
+		case POSTINCRV:
+		case POSTDECRV:
+		case INCRV:
+		case DECRV:
+		case POSTINCATRV:
+		case POSTDECATRV:
+		case INCATRV:
+		case DECATRV:
+
+		case UNMINUSR:
 			return 1;
 	
 		default:
@@ -250,12 +269,20 @@ static void operation_to_io(universal_io *const io, const item_t type)
 			uni_printf(io, "icmp sge");
 			break;
 
+		case INCR:
+		case INCRV:
+		case POSTINCR:
+		case POSTINCRV:
 		case PLUSASSR:
 		case PLUSASSRV:
 		case LPLUSR:
 			uni_printf(io, "fadd");
 			break;
 
+		case DECR:
+		case DECRV:
+		case POSTDECR:
+		case POSTDECRV:
 		case MINUSASSR:
 		case MINUSASSRV:
 		case LMINUSR:
@@ -798,7 +825,16 @@ static void inc_dec_expression(information *const info, node *const nd)
 	node_set_next(nd);
 	node_set_next(nd); // TIdent
 
-	to_code_load(info, info->register_num, displ, I32);
+	if (is_double(operation_type))
+	{
+		info->answer_value_type = DOUBLE;
+	}
+	else
+	{
+		info->answer_value_type = I32;
+	}
+
+	to_code_load(info, info->register_num, displ, info->answer_value_type);
 	info->answer_type = AREG;
 	info->answer_reg = info->register_num++;
 	
@@ -815,9 +851,21 @@ static void inc_dec_expression(information *const info, node *const nd)
 		case POSTDECV:
 			to_code_operation_reg_const_i32(info, operation_type, info->register_num - 1, 1);
 			break;
+
+		case INCR:
+		case INCRV:
+		case DECR:
+		case DECRV:
+			info->answer_reg = info->register_num;
+		case POSTINCR:
+		case POSTINCRV:
+		case POSTDECR:
+		case POSTDECRV:
+			to_code_operation_reg_const_double(info, operation_type, info->register_num - 1, 1.0);
+			break;
 	}
 
-	to_code_store_reg(info, info->register_num, displ, I32);
+	to_code_store_reg(info, info->register_num, displ, info->answer_value_type);
 	info->register_num++;
 }
 
@@ -833,6 +881,15 @@ static void unary_operation(information *const info, node *const nd)
 		case INCV:
 		case DEC:
 		case DECV:
+
+		case POSTINCR:
+		case POSTINCRV:
+		case POSTDECR:
+		case POSTDECRV:
+		case INCR:
+		case INCRV:
+		case DECR:
+		case DECRV:
 			inc_dec_expression(info, nd);
 			break;
 		case UNMINUS:

--- a/libs/compiler/llvmgen.c
+++ b/libs/compiler/llvmgen.c
@@ -57,7 +57,7 @@ typedef struct information
 
 
 static void expression(information *const info, node *const nd);
-static void block(information *const info, node *const nd);
+static void block(information *const info, node *const nd, int mode);
 
 
 static void operation_to_io(universal_io *const io, const item_t type)
@@ -913,10 +913,7 @@ static void statement(information *const info, node *const nd)
 	switch (node_get_type(nd))
 	{
 		case TBegin:
-		{
-			node_set_next(nd);
-			block(info, nd);
-		}
+			block(info, nd, 0);
 		break;
 		case TIf:
 		{
@@ -1167,8 +1164,9 @@ static void init(information *const info, node *const nd)
 	}
 }
 
-static void block(information *const info, node *const nd)
+static void block(information *const info, node *const nd, int mode)
 {
+	node_set_next(nd); // TBegin
 	while (node_get_type(nd) != TEnd)
 	{
 		switch (node_get_type(nd))
@@ -1218,7 +1216,11 @@ static void block(information *const info, node *const nd)
 				break;
 		}
 	}
-	node_set_next(nd); // TEnd
+
+	if (mode != -1)
+	{
+		node_set_next(nd); // TEnd
+	}
 }
 
 static int codegen(universal_io *const io, syntax *const sx)
@@ -1248,12 +1250,13 @@ static int codegen(universal_io *const io, syntax *const sx)
 				}
 				uni_printf(info.io, ") {\n");
 
-				node_set_next(&root); // TBegin
 				node_set_next(&root);
-				block(&info, &root);
+				block(&info, &root, -1);
 				uni_printf(info.io, "}\n\n");
 			}
 			break;
+			case TEnd:
+				break;
 			default:
 				system_error(node_unexpected, node_get_type(&root));
 				return -1;

--- a/libs/compiler/llvmgen.c
+++ b/libs/compiler/llvmgen.c
@@ -81,6 +81,7 @@ typedef struct information
 	// С одной стороны, arrays_info очень разреженный, что плохо
 	// С другой стороны, очень удобный доступ по displ, так как оно известно при вырезках 
 	array_info arrays_info[MAX_ARRAY_DISPL];	/**< Информация о массивах. Доступ осуществляется по displ */
+	// TODO: может лучше enum, а не 1 и 0?
 	int was_dynamic;							/**< Если в функции были динамические массивы, то @c 1, иначе @c 0 */
 } information;
 
@@ -415,7 +416,7 @@ static inline void to_code_conditional_branch(information *const info, item_t re
 		reg, label_true, label_false);
 }
 
-static void to_code_alloc_array_static(information *const info, const item_t id, type_t type)
+static void to_code_alloc_array_static(information *const info, item_t id, type_t type)
 {
 	uni_printf(info->io, " %%arr.%" PRIitem " = alloca ", id);
 
@@ -433,7 +434,7 @@ static void to_code_alloc_array_static(information *const info, const item_t id,
 	uni_printf(info->io, ", align 4\n");
 }
 
-static void to_code_alloc_array_dynamic(information *const info, const item_t id)
+static void to_code_alloc_array_dynamic(information *const info, item_t id)
 {
 	// выделение памяти на стеке
 	item_t to_alloc = info->arrays_info[id].borders[0];
@@ -701,7 +702,7 @@ static void assignment_expression(information *const info, node *const nd)
 	}
 }
 
-static void integral_expression(information *const info, node *const nd, const answer_t type)
+static void arithmetic_expression(information *const info, node *const nd)
 {
 	const item_t operation_type = node_get_type(nd);
 	node_set_next(nd);
@@ -860,7 +861,7 @@ static void integral_expression(information *const info, node *const nd, const a
 	}
 	
 	info->answer_reg = info->register_num++;
-	info->answer_type = type;
+	info->answer_type = AREG;
 }
 
 // Обрабатываются операции инкремента/декремента и постинкремента/постдекремента
@@ -979,7 +980,7 @@ static void unary_operation(information *const info, node *const nd)
 			node_set_next(nd);
 			expression(info, nd);
 		}
-		break;
+			break;
 		default:
 		{
 			node_set_next(nd);
@@ -1049,7 +1050,7 @@ static void binary_operation(information *const info, node *const nd)
 		case LMINUSR:
 		case LMULTR:
 		case LDIVR:
-			integral_expression(info, nd, AREG);
+			arithmetic_expression(info, nd);
 		break;
 
 
@@ -1067,9 +1068,12 @@ static void binary_operation(information *const info, node *const nd)
 		case LLER:
 		case LGER:
 		{
-			integral_expression(info, nd, ALOGIC);
-			
-			if (info->answer_type == ACONST)
+			arithmetic_expression(info, nd);
+			if (info->answer_type == AREG)
+			{
+				info->answer_type = ALOGIC;
+			}
+			else // ACONST 
 			{
 				info->answer_value_type = I32;
 			}
@@ -1081,8 +1085,8 @@ static void binary_operation(information *const info, node *const nd)
 		case LOGAND:
 		{
 			const item_t label_next = info->label_num++;
-			const item_t old_label_true = info->label_true;
-			const item_t old_label_false = info->label_false;
+			const item_t old_label_if = info->label_true;
+			const item_t old_label_else = info->label_false;
 
 			if (node_get_type(nd) == LOGOR)
 			{
@@ -1104,8 +1108,8 @@ static void binary_operation(information *const info, node *const nd)
 			}
 
 			to_code_label(info, label_next);
-			info->label_true = old_label_true;
-			info->label_false = old_label_false;
+			info->label_true = old_label_if;
+			info->label_false = old_label_else;
 
 			expression(info, nd);
 		}
@@ -1304,8 +1308,8 @@ static void statement(information *const info, node *const nd)
 		case TIf:
 		{
 			const item_t ref_else = node_get_arg(nd, 0);
-			const item_t old_label_true = info->label_true;
-			const item_t old_label_false = info->label_false;
+			const item_t old_label_if = info->label_true;
+			const item_t old_label_else = info->label_false;
 			const item_t label_if = info->label_num++;
 			const item_t label_else = info->label_num++;
 			const item_t label_end = info->label_num++;
@@ -1332,8 +1336,8 @@ static void statement(information *const info, node *const nd)
 			to_code_unconditional_branch(info, label_end);
 			to_code_label(info, label_end);
 
-			info->label_true = old_label_true;
-			info->label_false = old_label_false;
+			info->label_true = old_label_if;
+			info->label_false = old_label_else;
 		}
 		break;
 		case TSwitch:
@@ -1347,8 +1351,8 @@ static void statement(information *const info, node *const nd)
 		break;
 		case TWhile:
 		{
-			const item_t old_label_true = info->label_true;
-			const item_t old_label_false = info->label_false;
+			const item_t old_label_if = info->label_true;
+			const item_t old_label_else = info->label_false;
 			const item_t label_condition = info->label_num++;
 			const item_t label_body = info->label_num++;
 			const item_t label_end = info->label_num++;
@@ -1369,14 +1373,14 @@ static void statement(information *const info, node *const nd)
 			to_code_unconditional_branch(info, label_condition);
 			to_code_label(info, label_end);
 
-			info->label_true = old_label_true;
-			info->label_false = old_label_false;
+			info->label_true = old_label_if;
+			info->label_false = old_label_else;
 		}
 		break;
 		case TDo:
 		{
-			const item_t old_label_true = info->label_true;
-			const item_t old_label_false = info->label_false;
+			const item_t old_label_if = info->label_true;
+			const item_t old_label_else = info->label_false;
 			const item_t label_loop = info->label_num++;
 			const item_t label_end = info->label_num++;
 
@@ -1395,8 +1399,8 @@ static void statement(information *const info, node *const nd)
 
 			to_code_label(info, label_end);
 
-			info->label_true = old_label_true;
-			info->label_false = old_label_false;
+			info->label_true = old_label_if;
+			info->label_false = old_label_else;
 		}
 		break;
 		// TODO: проверялось, только если в for присутствуют все блоки: инициализация, условие, модификация
@@ -1406,8 +1410,8 @@ static void statement(information *const info, node *const nd)
 			const item_t ref_from = node_get_arg(nd, 0);
 			const item_t ref_cond = node_get_arg(nd, 1);
 			const item_t ref_incr = node_get_arg(nd, 2);
-			const item_t old_label_true = info->label_true;
-			const item_t old_label_false = info->label_false;
+			const item_t old_label_if = info->label_true;
+			const item_t old_label_else = info->label_false;
 			const item_t label_condition = info->label_num++;
 			const item_t label_body = info->label_num++;
 			const item_t label_incr = info->label_num++;
@@ -1445,8 +1449,8 @@ static void statement(information *const info, node *const nd)
 			to_code_unconditional_branch(info, label_incr);
 			to_code_label(info, label_end);
 
-			info->label_true = old_label_true;
-			info->label_false = old_label_false;
+			info->label_true = old_label_if;
+			info->label_false = old_label_else;
 		}
 		break;
 		case TLabel:
@@ -1690,8 +1694,8 @@ static int codegen(universal_io *const io, syntax *const sx)
 	info.answer_reg = 0;
 	info.answer_value_type = I32;
 
-	int was_stack_functions = 0;
 	node root = node_get_root(&sx->tree);
+	int was_stack_functions = 0;
 	while (node_set_next(&root) == 0)
 	{
 		switch (node_get_type(&root))

--- a/libs/compiler/llvmgen.c
+++ b/libs/compiler/llvmgen.c
@@ -43,7 +43,7 @@ typedef enum LOCATION
 typedef enum ARRAY_INFO
 {
 	DIMENSION,								/**< Размерность массива */
-	IS_STATIC,								/**< Если массив статический, то 1, иначе 0 */
+	IS_STATIC,								/**< Если массив статический, то @c 1, иначе @c 0 */
 	BORDERS,								/**< Граница массива: константы или номера регистров */
 } array_info_t;
 

--- a/libs/compiler/llvmgen.c
+++ b/libs/compiler/llvmgen.c
@@ -1206,10 +1206,10 @@ static void block(information *const info, node *const nd)
 				}
 
 				const item_t displ = node_get_arg(&id, 0);
-				const size_t index = hash_add(&info->arrays, displ, 1 + N);
+				const size_t index = hash_add(&info->arrays, displ, 1 + (size_t)N);
 
 				node_set_next(nd);
-				for (item_t i = 0; i < N; i++)
+				for (size_t i = 0; i < (size_t)N; i++)
 				{
 					info->variable_location = LFREE;
 					expression(info, nd);

--- a/libs/compiler/llvmgen.c
+++ b/libs/compiler/llvmgen.c
@@ -15,18 +15,16 @@
  */
 
 #include "llvmgen.h"
-#include "codes.h"
 #include "errors.h"
 #include "llvmopt.h"
 #include "tree.h"
 #include "uniprinter.h"
-#include <string.h>
 
 
 #define MAX_ARRAY_DIMENSION		5
 #define MAX_ARRAY_DISPL			10000
 
-
+// TODO: нужно создать enum для типов и передавать его в функции to_code
 typedef enum ANSWER
 {
 	AREG,								/**< Ответ находится в регистре */
@@ -40,13 +38,6 @@ typedef enum LOCATION
 	LMEM,								/**< Переменная находится в памяти */
 	LFREE,								/**< Свободный запрос значения */
 } location_t;
-
-// TODO: за типом ответа пока следится только в TIdenttoval и TIdenttovald, а надо везде
-typedef enum TYPES
-{
-	I32,								/**< int */
-	DOUBLE,								/**< double */
-} type_t;
 
 typedef struct array_info
 {
@@ -71,7 +62,6 @@ typedef struct information
 	item_t answer_reg;							/**< Регистр с ответом */
 	item_t answer_const;						/**< Константа с ответом */
 	answer_t answer_type;						/**< Тип ответа */
-	type_t answer_reg_type;						/**< Тип значения в регистре */
 
 	item_t label_true;							/**< Метка перехода при true */
 	item_t label_false;							/**< Метка перехода при false */
@@ -89,28 +79,6 @@ typedef struct information
 static void expression(information *const info, node *const nd);
 static void block(information *const info, node *const nd);
 
-
-static double to_double(const int64_t fst, const int64_t snd)
-{
-	int64_t num = (snd << 32) | (fst & 0x00000000ffffffff);
-	double numdouble;
-	memcpy(&numdouble, &num, sizeof(double));
-	
-	return numdouble;
-}
-
-static void type_to_io(universal_io *const io, const type_t type)
-{
-	switch (type)
-	{
-		case I32:
-			uni_printf(io, "i32");
-			break;
-		case DOUBLE:
-			uni_printf(io, "double");
-			break;
-	}
-}
 
 static void operation_to_io(universal_io *const io, const item_t type)
 {
@@ -226,13 +194,9 @@ static void to_code_operation_const_reg(information *const info, item_t type, it
 	uni_printf(info->io, " i32 %" PRIitem ", %%.%" PRIitem "\n", fst, snd);
 }
 
-static void to_code_load(information *const info, item_t result, item_t displ, type_t type)
+static inline void to_code_load(information *const info, item_t result, item_t displ)
 {
-	uni_printf(info->io, " %%.%" PRIitem " = load ", result);
-	type_to_io(info->io, type);
-	uni_printf(info->io, ", ");
-	type_to_io(info->io, type);
-	uni_printf(info->io, "* %%var.%" PRIitem ", align 4\n", displ);
+	uni_printf(info->io, " %%.%" PRIitem " = load i32, i32* %%var.%" PRIitem ", align 4\n", result, displ);
 }
 
 static inline void to_code_store_reg(information *const info, item_t reg, item_t displ)
@@ -240,14 +204,9 @@ static inline void to_code_store_reg(information *const info, item_t reg, item_t
 	uni_printf(info->io, " store i32 %%.%" PRIitem ", i32* %%var.%" PRIitem ", align 4\n", reg, displ);
 }
 
-static inline void to_code_store_const_i32(information *const info, item_t arg, item_t displ)
+static inline void to_code_store_const(information *const info, item_t arg, item_t displ)
 {
 	uni_printf(info->io, " store i32 %" PRIitem ", i32* %%var.%" PRIitem ", align 4\n", arg, displ);
-}
-
-static void to_code_store_const_double(information *const info, item_t arg1, item_t arg2, item_t displ)
-{
-	uni_printf(info->io, " store double %f, double* %%var.%" PRIitem ", align 4\n", to_double(arg1, arg2), displ);
 }
 
 static void to_code_try_zext_to(information *const info)
@@ -357,28 +316,18 @@ static void operand(information *const info, node *const nd)
 	{
 		case TIdent:
 		case TSelect:
+		case TIdenttovald:
 		case TIdenttoaddr:
+		case TConstd:
 			node_set_next(nd);
 			break;
 		case TIdenttoval:
 		{
 			const item_t displ = node_get_arg(nd, 0);
 
-			to_code_load(info, info->register_num, displ, I32);
+			to_code_load(info, info->register_num, displ);
 			info->answer_reg = info->register_num++;
 			info->answer_type = AREG;
-			info->answer_reg_type = I32;
-			node_set_next(nd);
-		}
-		break;
-		case TIdenttovald:
-		{
-			const item_t displ = node_get_arg(nd, 0);
-
-			to_code_load(info, info->register_num, displ, DOUBLE);
-			info->answer_reg = info->register_num++;
-			info->answer_type = AREG;
-			info->answer_reg_type = DOUBLE;
 			node_set_next(nd);
 		}
 		break;
@@ -388,28 +337,13 @@ static void operand(information *const info, node *const nd)
 
 			if (info->variable_location == LMEM)
 			{
-				to_code_store_const_i32(info, num, info->request_reg);
+				to_code_store_const(info, num, info->request_reg);
 				info->answer_type = AREG;
 			}
 			else
 			{
 				info->answer_type = ACONST;
 				info->answer_const = num;
-			}
-
-			node_set_next(nd);
-		}
-		break;
-		case TConstd:
-		{
-			if (info->variable_location == LMEM)
-			{
-				to_code_store_const_double(info, node_get_arg(nd, 0), node_get_arg(nd, 1), info->request_reg);
-				info->answer_type = AREG;
-			}
-			else
-			{
-				// TODO: обработать этот случай аналогично TConst
 			}
 
 			node_set_next(nd);
@@ -505,7 +439,7 @@ static void assignment_expression(information *const info, node *const nd)
 
 	if (assignment_type != ASS && assignment_type != ASSV)
 	{
-		to_code_load(info, info->register_num, displ, I32);
+		to_code_load(info, info->register_num, displ);
 		info->register_num++;
 
 		if (info->answer_type == AREG)
@@ -526,7 +460,7 @@ static void assignment_expression(information *const info, node *const nd)
 	}
 	else // ACONST && =
 	{
-		to_code_store_const_i32(info, info->answer_const, displ);
+		to_code_store_const(info, info->answer_const, displ);
 	}
 }
 
@@ -636,7 +570,7 @@ static void inc_dec_expression(information *const info, node *const nd)
 	node_set_next(nd);
 	node_set_next(nd); // TIdent
 
-	to_code_load(info, info->register_num, displ, I32);
+	to_code_load(info, info->register_num, displ);
 	info->answer_type = AREG;
 	info->answer_reg = info->register_num++;
 	
@@ -1199,7 +1133,6 @@ static void statement(information *const info, node *const nd)
 		{
 			const item_t N = node_get_arg(nd, 0);
 			item_t args[128];
-			type_t args_type[128];
 
 			node_set_next(nd);
 			const item_t string_length = node_get_arg(nd, 0);
@@ -1210,7 +1143,6 @@ static void statement(information *const info, node *const nd)
 				info->variable_location = LREG;
 				expression(info, nd);
 				args[i] = info->answer_reg;
-				args_type[i] = info->answer_reg_type;
 			}
 
 			uni_printf(info->io, " %%.%" PRIitem " = call i32 (i8*, ...) @printf(i8* getelementptr inbounds "
@@ -1225,9 +1157,7 @@ static void statement(information *const info, node *const nd)
 
 			for (item_t i = 0; i < N; i++)
 			{
-				uni_printf(info->io, ", ");
-				type_to_io(info->io, args_type[i]);
-				uni_printf(info->io, " signext %%.%" PRIitem, args[i]);
+				uni_printf(info->io, ", i32 signext %%.%" PRIitem, args[i]);
 			}
 
 			uni_printf(info->io, ")\n");
@@ -1287,7 +1217,7 @@ static void block(information *const info, node *const nd)
 					{
 						info->current_array_info.borders[i] = info->answer_const;
 					}
-					else // if (info->answer_type == AREG) динамический массив
+					else // if (info->answer_type == ARER) динамический массив
 					{
 						info->current_array_info.borders[i] = info->answer_reg;
 						info->current_array_info.is_static = 0;
@@ -1325,6 +1255,7 @@ static void block(information *const info, node *const nd)
 					}
 					else
 					{
+						// TODO: нужно ещё сделать восстановление стека после выделения памяти
 						if (!info->was_dynamic)
 						{
 							to_code_stack_save(info);
@@ -1364,7 +1295,6 @@ static int codegen(universal_io *const io, syntax *const sx)
 	info.variable_location = LREG;
 	info.request_reg = 0;
 	info.answer_reg = 0;
-	info.answer_reg_type = I32;
 
 	node root = node_get_root(&sx->tree);
 	int was_stack_functions = 0;
@@ -1432,7 +1362,6 @@ int encode_to_llvm(const workspace *const ws, universal_io *const io, syntax *co
 	{
 		return -1;
 	}
-	tree_print("new1.txt", &(sx->tree));
 
 	return codegen(io, sx);
 }

--- a/libs/compiler/llvmgen.c
+++ b/libs/compiler/llvmgen.c
@@ -693,7 +693,7 @@ static void binary_operation(information *const info, node *const nd)
 			logic_expression(info, nd);
 			break;
 
-
+		// TODO: протестировать и при необходимости реализовать случай, когда && и || есть в арифметических выражениях
 		case LOGOR:
 		case LOGAND:
 		{

--- a/libs/compiler/llvmgen.c
+++ b/libs/compiler/llvmgen.c
@@ -315,6 +315,12 @@ static void operand(information *const info, node *const nd)
 			{
 				uni_printf(info->io, " call void @func%zi(", ref_ident);
 			}
+			else if (func_type == LINT)
+			{
+				uni_printf(info->io, " %%.%" PRIitem " = call i32 @func%zi(", info->register_num, ref_ident);
+				info->answer_type = AREG;
+				info->answer_reg = info->register_num++;
+			}
 			// тут будет ещё перечисление аргументов
 			uni_printf(info->io, ")\n");
 		}
@@ -1103,6 +1109,7 @@ static void statement(information *const info, node *const nd)
 			node_set_next(nd);
 			info->variable_location = LREG;
 			expression(info, nd);
+			// TODO: добавить обработку других ответов
 			if (info->answer_type == ACONST)
 			{
 				uni_printf(info->io, " ret i32 %" PRIitem "\n", info->answer_const);
@@ -1268,6 +1275,10 @@ static int codegen(universal_io *const io, syntax *const sx)
 				else if (func_type == LVOID)
 				{
 					uni_printf(info.io, "define void @func%zi(", ref_ident);
+				}
+				else if (func_type == LINT)
+				{
+					uni_printf(info.io, "define i32 @func%zi(", ref_ident);
 				}
 				uni_printf(info.io, ") {\n");
 

--- a/libs/compiler/llvmopt.c
+++ b/libs/compiler/llvmopt.c
@@ -345,7 +345,6 @@ static int node_recursive(information *const info, node *const nd)
 					{
 						// TODO: а какая depth, если у вызова есть аргументы?
 						// это пока временное решение, с наличием агрументов будет другая реализация
-						// TODO: что-то не так при перестановке с x = func1d(); TIdent в начале выражения, а не после =
 						if (node_get_type(&child) == TCall1)
 						{
 							nd_info.depth = 2;

--- a/libs/compiler/llvmopt.c
+++ b/libs/compiler/llvmopt.c
@@ -345,6 +345,7 @@ static int node_recursive(information *const info, node *const nd)
 					{
 						// TODO: а какая depth, если у вызова есть аргументы?
 						// это пока временное решение, с наличием агрументов будет другая реализация
+						// TODO: что-то не так при перестановке с x = func1d(); TIdent в начале выражения, а не после =
 						if (node_get_type(&child) == TCall1)
 						{
 							nd_info.depth = 2;

--- a/libs/compiler/llvmopt.c
+++ b/libs/compiler/llvmopt.c
@@ -303,27 +303,20 @@ static int node_recursive(information *const info, node *const nd)
 			break;
 			case TPrintf:
 			{
-				size_t N = (size_t)node_get_arg(&child, 0);
+				const size_t N = (size_t)node_get_arg(&child, 0);
 				// перестановка TPrintf
+				// TODO: подумать, как для всех типов работать будет
 				for (size_t j = 0; j < N + 1; j++)
 				{
 					node_swap(nd, i - j, nd, i - j - 1);
-
-					node child_to_swap = node_get_child(nd, i - j);
-					if (node_get_type(&child_to_swap) == TIdenttovald)
-					{
-						N--;
-					}
 				}
 
 				// перестановка TString
+				// TODO: подумать, как для всех типов работать будет
 				for (size_t j = 0; j < N; j++)
 				{
 					node_swap(nd, i - j, nd, i - j - 1);
 				}
-
-				node printf_node = node_get_child(nd, i - N - 1);
-				node_set_arg(&printf_node, 0, N);
 
 				info->was_printf = 1;
 			}

--- a/libs/compiler/llvmopt.c
+++ b/libs/compiler/llvmopt.c
@@ -303,20 +303,27 @@ static int node_recursive(information *const info, node *const nd)
 			break;
 			case TPrintf:
 			{
-				const size_t N = (size_t)node_get_arg(&child, 0);
+				size_t N = (size_t)node_get_arg(&child, 0);
 				// перестановка TPrintf
-				// TODO: подумать, как для всех типов работать будет
 				for (size_t j = 0; j < N + 1; j++)
 				{
 					node_swap(nd, i - j, nd, i - j - 1);
+
+					node child_to_swap = node_get_child(nd, i - j);
+					if (node_get_type(&child_to_swap) == TIdenttovald)
+					{
+						N--;
+					}
 				}
 
 				// перестановка TString
-				// TODO: подумать, как для всех типов работать будет
 				for (size_t j = 0; j < N; j++)
 				{
 					node_swap(nd, i - j, nd, i - j - 1);
 				}
+
+				node printf_node = node_get_child(nd, i - N - 1);
+				node_set_arg(&printf_node, 0, N);
 
 				info->was_printf = 1;
 			}

--- a/libs/compiler/llvmopt.c
+++ b/libs/compiler/llvmopt.c
@@ -355,6 +355,13 @@ static int node_recursive(information *const info, node *const nd)
 						// перестановка со вторым операндом
 						has_error |= transposition(second, &nd_info);
 
+						// надо переставить second с родителем
+						if (node_get_type(second->parent) == ADLOGOR || node_get_type(second->parent) == ADLOGAND)
+						{
+							node_info log_info = { second->parent, 1, 1 };
+							has_error |= transposition(second, &log_info);
+						}
+
 						// перестановка с первым операндом
 						has_error |= transposition(first, second);
 

--- a/libs/compiler/llvmopt.c
+++ b/libs/compiler/llvmopt.c
@@ -109,6 +109,7 @@ static expression_t expression_type(node *const nd)
 		case TIdenttoaddr:
 		case TConstd:
 		case TIdenttovald:
+		case TCall1:
 			return OPERAND;
 
 
@@ -334,8 +335,16 @@ static int node_recursive(information *const info, node *const nd)
 				switch (expression_type(&child))
 				{
 					case OPERAND:
+					{
+						// TODO: а какая depth, если у вызова есть аргументы?
+						// это пока временное решение, с наличием агрументов будет другая реализация
+						if (node_get_type(&child) == TCall1)
+						{
+							nd_info.depth = 2;
+						}
 						stack_push(info, &nd_info);
-						break;
+					}
+					break;
 					case UNARY_OPERATION:
 					{
 						node_info *operand = stack_pop(info);

--- a/libs/compiler/parser.h
+++ b/libs/compiler/parser.h
@@ -23,7 +23,7 @@
 #include "uniio.h"
 
 
-//#define GENERATE_TREE
+#define GENERATE_TREE
 
 #define TREE		(prs->sx->tree)
 

--- a/libs/compiler/parser.h
+++ b/libs/compiler/parser.h
@@ -23,7 +23,7 @@
 #include "uniio.h"
 
 
-#define GENERATE_TREE
+//#define GENERATE_TREE
 
 #define TREE		(prs->sx->tree)
 

--- a/src/main.c
+++ b/src/main.c
@@ -30,8 +30,6 @@ int main(int argc, const char *argv[])
 {
 	workspace ws = ws_parse_args(argc, argv);
 
-	ws_add_flag(&ws, "-LLVM");
-
 	if (argc < 2)
 	{
 		ws_add_file(&ws, name);


### PR DESCRIPTION
В связи с разговором 21.04.2021 представляю урезанную реализацию условий и циклов. Условные конструкции и циклы работают за исключением некоторых случаев. Следующие задачи пока не сделаны:

- [x] объединить функции arithmetic_expression и logic_expression в связи с дубликацией кода
- [ ] реализовать битовое отрицание (в прошлом pull request по арифметическим выражениям забыл сделать это)
- [ ] реализовать работу && и || с не логическими выражениями (например, сейчас не будет работать i && 5)
- [ ] протестировать и при необходимости реализовать случай, когда && и || есть в арифметических выражениях
- [ ] цикл for сейчас работает только в случае, если присутствуют все блоки: инициализация, условие, модификация. Соответственно, нужно реализовать и для случаев с их отсутствием
- [ ] в цикле for не проверено, что будет, если условие не является логическим

Данные замечания продублированы в коде в комментариях TODO. В остальном по условным выражениям и циклам всё сделано.

Также реализованы объявления и вызов функций, тоже в ограниченном варианте. Работают только функции типа void и int без аргументов. Других типов не возвращается, так как это будет реализовываться в рамках введения других типов. Передача аргументов не реализована в связи с проблемами в построении дерева [ссылка на issue в gitlab](https://gitlab.softcom.su/ruc/ruc/-/issues/127)

Также реализованы объявления статических и динамических массивов. По измерению я взял ограничение 5, но это легко исправить, просто нужно конечное число. Единственное, я пока не проверил случай, когда часть границ массива статическая, а часть динамическая. Вырезку из массива я пока не могу реализовать из-за проблем с работой с деревом [ссылка на issue в gitlab](https://gitlab.softcom.su/ruc/ruc/-/issues/128).