### PR TITLE
Фикс дерева для списков инициализации

### DIFF
--- a/libs/compiler/parser.h
+++ b/libs/compiler/parser.h
@@ -265,7 +265,7 @@ void parse_declaration_inner(parser *const prs, node *const parent);
 void parse_declaration_external(parser *const prs, node *const root);
 
 /**
- *	Parse initializer [C99 6.7.8]
+ *	Parse initializer [C99 6.7.8p1]
  *
  *	initializer:
  *		assignment-expression
@@ -278,7 +278,10 @@ void parse_declaration_external(parser *const prs, node *const root);
 void parse_initializer(parser *const prs, node *const parent, const item_t type);
 
 /**
- *	Parse braced initializer
+ *	Parse braced initializer list [C99 6.7.8p2]
+ *
+ *	initializer-list:
+ *		initializer-list ',' initializer
  *
  *	@param	prs			Parser structure
  *	@param	parent		Parent node in AST

--- a/libs/compiler/parser.h
+++ b/libs/compiler/parser.h
@@ -277,6 +277,15 @@ void parse_declaration_external(parser *const prs, node *const root);
  */
 void parse_initializer(parser *const prs, node *const parent, const item_t type);
 
+/**
+ *	Parse braced initializer
+ *
+ *	@param	prs			Parser structure
+ *	@param	parent		Parent node in AST
+ *	@param	type		Type of variable in declaration
+ */
+void parse_braced_initializer(parser *const prs, node *const parent, const item_t type);
+
 
 /**
  *	Parse statement [C99 6.8]

--- a/libs/compiler/parser_decl.c
+++ b/libs/compiler/parser_decl.c
@@ -290,8 +290,7 @@ static item_t parse_struct_declaration_list(parser *const prs, node *const paren
 						prs->flag_strings_only = 2;
 						node_set_arg(&nd_decl_id, 3, 1);
 
-						parse_array_initializer(prs, &nd_decl_arr, type);
-						node_add_child(&prs->nd, OP_EXPR_END);
+						parse_initializer(prs, &nd_decl_arr, type);
 						if (prs->flag_strings_only == 1)
 						{
 							node_set_arg(&nd_decl_id, 5, prs->flag_empty_bounds + 2);
@@ -396,6 +395,7 @@ static void parse_array_initializer(parser *const prs, node *const parent, const
 		}
 		parse_string_literal(prs, parent);
 		to_tree(prs, OP_EXPR_END);
+		node_copy(&prs->nd, parent);
 		return;
 	}
 
@@ -403,6 +403,9 @@ static void parse_array_initializer(parser *const prs, node *const parent, const
 	{
 		parser_error(prs, arr_init_must_start_from_BEGIN);
 		token_skip_until(prs, TK_COMMA | TK_SEMICOLON);
+
+		// Это для продолжения парсинга
+		node_copy(&prs->nd, parent);
 		return;
 	}
 
@@ -933,6 +936,7 @@ void parse_braced_initializer(parser *const prs, node *const parent, const item_
 	}
 	else
 	{
+		node_copy(&prs->nd, parent);
 		parser_error(prs, wrong_init);
 		token_skip_until(prs, TK_COMMA | TK_SEMICOLON);
 	}

--- a/libs/compiler/parser_expr.c
+++ b/libs/compiler/parser_expr.c
@@ -1437,7 +1437,7 @@ static void parse_assignment_expression_internal(parser *const prs)
 		const item_t type = prs->left_mode;
 		if (mode_is_struct(prs->sx, type) || mode_is_array(prs->sx, type))
 		{
-			parse_initializer(prs, &prs->nd, type);
+			parse_braced_initializer(prs, &prs->nd, type);
 			prs->left_mode = type;
 		}
 		else


### PR DESCRIPTION
Ошибка заключалась в том, что список инициализации оставлял после себя лишний EXPR_END. 
Теперь `parse_initializer`  вызывается только для разбора правой части объявлений и аргументов функций, для прочих использований была добавлена функция `parse_braced_initializer`, которая может быть частью частью выражения, а вызывающий сам подставит признак окончания выражения в случае необходимости.