### PR TITLE
Узлы return и объявлений

### DIFF
--- a/libs/compiler/codes.c
+++ b/libs/compiler/codes.c
@@ -268,78 +268,40 @@ static size_t elem_get_name(const item_t elem, const size_t num, char *const buf
 					break;
 			}
 			break;
-		case OP_DECL_ARR:
+		case OP_DECL_VAR:
+			argc = 3;
+			was_switch = true;
+			switch (num)
+			{
+				case 0:
+					sprintf(buffer, "VAR_DECL");
+					break;
+				case 1:
+					sprintf(buffer, "id");
+					break;
+				case 2:
+					sprintf(buffer, "dim");
+					break;
+				case 3:
+					sprintf(buffer, "init");
+					break;
+			}
+			break;
+		case OP_DECL_TYPE:
 			argc = 1;
 			was_switch = true;
 			switch (num)
 			{
 				case 0:
-					sprintf(buffer, "TDeclarr");
+					sprintf(buffer, "TYPE_DECL");
 					break;
 				case 1:
-					sprintf(buffer, "N");
-					break;
-			}
-			break;
-		case OP_DECL_ID:
-			argc = 7;
-			was_switch = true;
-			switch (num)
-			{
-				case 0:
-					sprintf(buffer, "TDeclid");
-					break;
-				case 1:
-					sprintf(buffer, "displ");
-					break;
-				case 2:
-					sprintf(buffer, "eltype");
-					break;
-				case 3:
-					sprintf(buffer, "N");
-					break;
-				case 4:
-					sprintf(buffer, "all");
-					break;
-				case 5:
-					sprintf(buffer, "iniproc");
-					break;
-				case 6:
-					sprintf(buffer, "usual");
-					break;
-				case 7:
-					sprintf(buffer, "instuct");
+					sprintf(buffer, "type_id");
 					break;
 			}
 			break;
 		case OP_BLOCK:
 			sprintf(buffer, "TBegin");
-			break;
-		case OP_ARRAY_INIT:
-			argc = 1;
-			was_switch = true;
-			switch (num)
-			{
-				case 0:
-					sprintf(buffer, "TBeginit");
-					break;
-				case 1:
-					sprintf(buffer, "n");
-					break;
-			}
-			break;
-		case OP_STRUCT_INIT:
-			argc = 1;
-			was_switch = true;
-			switch (num)
-			{
-				case 0:
-					sprintf(buffer, "TStructinit");
-					break;
-				case 1:
-					sprintf(buffer, "n");
-					break;
-			}
 			break;
 		case OP_IF:
 			argc = 1;
@@ -518,14 +480,6 @@ static size_t elem_get_name(const item_t elem, const size_t num, char *const buf
 		case OP_LABEL:
 			argc = 1;
 			sprintf(buffer, "TLabel");
-			break;
-		case OP_DECL_STRUCT:
-			argc = 1;
-			sprintf(buffer, "TStructbeg");
-			break;
-		case OP_DECL_STRUCT_END:
-			argc = 1;
-			sprintf(buffer, "TStructend");
 			break;
 		case IC_CREATE:
 			sprintf(buffer, "TCREATE");

--- a/libs/compiler/codes.c
+++ b/libs/compiler/codes.c
@@ -274,7 +274,7 @@ static size_t elem_get_name(const item_t elem, const size_t num, char *const buf
 			switch (num)
 			{
 				case 0:
-					sprintf(buffer, "VAR_DECL");
+					sprintf(buffer, "DECL_VAR");
 					break;
 				case 1:
 					sprintf(buffer, "id");
@@ -293,7 +293,7 @@ static size_t elem_get_name(const item_t elem, const size_t num, char *const buf
 			switch (num)
 			{
 				case 0:
-					sprintf(buffer, "TYPE_DECL");
+					sprintf(buffer, "DECL_TYPE");
 					break;
 				case 1:
 					sprintf(buffer, "type_id");

--- a/libs/compiler/codes.c
+++ b/libs/compiler/codes.c
@@ -332,12 +332,8 @@ static size_t elem_get_name(const item_t elem, const size_t num, char *const buf
 		case OP_CONTINUE:
 			sprintf(buffer, "TContinue");
 			break;
-		case OP_RETURN_VOID:
+		case OP_RETURN:
 			sprintf(buffer, "TReturn");
-			break;
-		case OP_RETURN_VAL:
-			argc = 1;
-			sprintf(buffer, "TReturnval");
 			break;
 		case OP_GOTO:
 			argc = 1;

--- a/libs/compiler/operations.h
+++ b/libs/compiler/operations.h
@@ -130,15 +130,9 @@ typedef enum OPERATION
 	OP_THREAD,				/**< Create direct thread node */
 
 	// Declarations
-	OP_DECL_ID,				/**< Identifier declaration node */
-	OP_DECL_ARR,			/**< Array declaration node */
-	OP_DECL_STRUCT,			/**< Struct declaration node */
+	OP_DECL_VAR,			/**< Variable declaration node */
+	OP_DECL_TYPE,			/**< Type declaration node */
 	OP_FUNC_DEF,			/**< Function definition node */
-	OP_ARRAY_INIT,			/**< Array inition node */
-	OP_STRUCT_INIT,			/**< Struct inition node */
-
-	// End nodes
-	OP_DECL_STRUCT_END,		/**< End of struct declaration node */
 
 	// Built-in functions
 	OP_PRINTID,

--- a/libs/compiler/operations.h
+++ b/libs/compiler/operations.h
@@ -125,8 +125,7 @@ typedef enum OPERATION
 	OP_GOTO,				/**< Goto statement node */
 	OP_CONTINUE,			/**< Continue statement node */
 	OP_BREAK,				/**< Break statement node */
-	OP_RETURN_VOID,			/**< Void return statement node */
-	OP_RETURN_VAL,			/**< Valued return statement node */
+	OP_RETURN,				/**< Return statement node */
 	OP_THREAD,				/**< Create direct thread node */
 
 	// Declarations

--- a/libs/compiler/parser.h
+++ b/libs/compiler/parser.h
@@ -221,25 +221,6 @@ void parse_declaration_external(parser *const prs, node *const root);
  */
 void parse_statement(parser *const prs, node *const parent);
 
-/**
- *	Parse '{}' block [C99 6.8.2]
- *
- *	compound-statement:
- *  	'{' block-item-list[opt] '}'
- *
- *	block-item-list:
- *		block-item
- *		block-item-list block-item
- *
- *	block-item:
- *		declaration
- *		statement
- *
- *	@param	prs			Parser
- *	@param	parent		Parent node in AST
- */
-void parse_statement_compound(parser *const prs, node *const parent, const block_t type);
-
 
 /**
  *	Add new item to identifiers table

--- a/libs/compiler/parser.h
+++ b/libs/compiler/parser.h
@@ -221,6 +221,25 @@ void parse_declaration_external(parser *const prs, node *const root);
  */
 void parse_statement(parser *const prs, node *const parent);
 
+/**
+ *	Parse '{}' block [C99 6.8.2]
+ *
+ *	compound-statement:
+ *  	'{' block-item-list[opt] '}'
+ *
+ *	block-item-list:
+ *		block-item
+ *		block-item-list block-item
+ *
+ *	block-item:
+ *		declaration
+ *		statement
+ *
+ *	@param	prs			Parser
+ *	@param	parent		Parent node in AST
+ */
+void parse_statement_compound(parser *const prs, node *const parent, const block_t type);
+
 
 /**
  *	Add new item to identifiers table

--- a/libs/compiler/parser.h
+++ b/libs/compiler/parser.h
@@ -35,7 +35,6 @@ typedef enum BLOCK
 	REGBLOCK,
 	THREAD,
 	FUNCBODY,
-	FORBLOCK,
 } block_t;
 
 

--- a/libs/compiler/parser_decl.c
+++ b/libs/compiler/parser_decl.c
@@ -647,7 +647,7 @@ static void parse_function_body(parser *const prs, node *const parent, const siz
 
 	func_set(prs->sx, function_number, node_save(&nd)); // Ссылка на расположение в дереве
 
-	parse_statement(prs, &nd);
+	parse_statement_compound(prs, &nd, FUNCBODY);
 
 	if (type_get(prs->sx, prs->function_mode + 1) != TYPE_VOID && !prs->was_return)
 	{

--- a/libs/compiler/parser_decl.c
+++ b/libs/compiler/parser_decl.c
@@ -261,17 +261,18 @@ static item_t parse_struct_declaration_list(parser *const prs, node *const paren
 				node nd_decl = node_add_child(&nd, OP_DECL_VAR);
 				node_add_arg(&nd_decl, 0);	// Вместо id подставим тип
 				node_add_arg(&nd_decl, 0);	// Тут будет размерность
+				node_add_arg(&nd_decl, 0);	// Тут будет флаг наличия инициализатора
 
 				// Меняем тип (увеличиваем размерность массива)
 				type = parse_array_definition(prs, &nd_decl, element_type);
 
-				node_set_arg(&nd, 0, type);
-				node_set_arg(&nd, 1, (item_t)prs->array_dimensions);
+				node_set_arg(&nd_decl, 0, type);
+				node_set_arg(&nd_decl, 1, (item_t)prs->array_dimensions);
 
 				if (token_try_consume(prs, TK_EQUAL) && type_is_array(prs->sx, type))
 				{
-					node_set_arg(&nd, 2, true);
-					node_copy(&prs->sx->nd, &nd);
+					node_set_arg(&nd_decl, 2, true);
+					node_copy(&prs->sx->nd, &nd_decl);
 
 					const node initializer = parse_initializer(prs, type);
 					if (!node_is_correct(&initializer))

--- a/libs/compiler/parser_decl.c
+++ b/libs/compiler/parser_decl.c
@@ -647,7 +647,7 @@ static void parse_function_body(parser *const prs, node *const parent, const siz
 
 	func_set(prs->sx, function_number, node_save(&nd)); // Ссылка на расположение в дереве
 
-	parse_statement_compound(prs, &nd, FUNCBODY);
+	parse_statement(prs, &nd);
 
 	if (type_get(prs->sx, prs->function_mode + 1) != TYPE_VOID && !prs->was_return)
 	{

--- a/libs/compiler/parser_stmt.c
+++ b/libs/compiler/parser_stmt.c
@@ -348,14 +348,7 @@ static void parse_for_statement(parser *const prs, node *const parent)
 
 	const bool old_in_loop = prs->is_in_loop;
 	prs->is_in_loop = true;
-	if (prs->token == TK_L_BRACE)
-	{
-		parse_statement_compound(prs, &nd, FORBLOCK);
-	}
-	else
-	{
-		parse_statement(prs, &nd);
-	}
+	parse_statement(prs, &nd);
 
 	prs->is_in_loop = old_in_loop;
 	scope_block_exit(prs->sx, old_displ, old_lg);
@@ -800,7 +793,7 @@ void parse_statement_compound(parser *const prs, node *const parent, const block
 	item_t old_displ = 0;
 	item_t old_lg = 0;
 
-	if (type != FUNCBODY && type != FORBLOCK)
+	if (type != FUNCBODY)
 	{
 		scope_block_enter(prs->sx, &old_displ, &old_lg);
 	}
@@ -824,11 +817,7 @@ void parse_statement_compound(parser *const prs, node *const parent, const block
 		token_expect_and_consume(prs, end_token, expected_end);
 	}
 
-	if (type == FUNCBODY)
-	{
-		node_add_child(&nd_block, OP_RETURN_VOID);
-	}
-	else if (type != FORBLOCK)
+	if (type != FUNCBODY)
 	{
 		scope_block_exit(prs->sx, old_displ, old_lg);
 	}

--- a/libs/compiler/parser_stmt.c
+++ b/libs/compiler/parser_stmt.c
@@ -454,9 +454,10 @@ static void parse_return_statement(parser *const prs, node *const parent)
 	const item_t return_type = type_get(prs->sx, prs->function_mode + 1);
 	prs->was_return = true;
 
+	node nd = node_add_child(parent, OP_RETURN);
+
 	if (token_try_consume(prs, TK_SEMICOLON))
 	{
-		node_add_child(parent, OP_RETURN_VOID);
 		if (!type_is_void(return_type))
 		{
 			parser_error(prs, no_ret_in_func);
@@ -468,9 +469,6 @@ static void parse_return_statement(parser *const prs, node *const parent)
 		{
 			parser_error(prs, notvoidret_in_void_func);
 		}
-
-		node nd = node_add_child(parent, OP_RETURN_VAL);
-		node_add_arg(&nd, (item_t)type_size(prs->sx, return_type));
 
 		node_copy(&prs->sx->nd, &nd);
 		const node nd_expr = parse_assignment_expression(prs);

--- a/libs/compiler/parser_stmt.c
+++ b/libs/compiler/parser_stmt.c
@@ -152,6 +152,65 @@ static void parse_default_statement(parser *const prs, node *const parent)
 }
 
 /**
+ *	Parse compound statement [C99 6.8.2]
+ *
+ *	compound-statement:
+ *  	'{' block-item-list[opt] '}'
+ *
+ *	block-item-list:
+ *		block-item
+ *		block-item-list block-item
+ *
+ *	block-item:
+ *		declaration
+ *		statement
+ *
+ *	@param	prs			Parser
+ *	@param	parent		Parent node in AST
+ */
+static void parse_compound_statement(parser *const prs, node *const parent, const block_t type)
+{
+	token_consume(prs); // '{' or kw_create_direct
+	node nd_block = node_add_child(parent, OP_BLOCK);
+
+	item_t old_displ = 0;
+	item_t old_lg = 0;
+
+	if (type != FUNCBODY && type != FORBLOCK)
+	{
+		scope_block_enter(prs->sx, &old_displ, &old_lg);
+	}
+
+	const token_t end_token = (type == THREAD) ? TK_EXIT_DIRECT : TK_R_BRACE;
+	if (!token_try_consume(prs, end_token))
+	{
+		while (prs->token != TK_EOF && prs->token != end_token)
+		{
+			// Почему не ловилась ошибка, если в блоке нити встретилась '}'?
+			if (is_declaration_specifier(prs))
+			{
+				parse_declaration_inner(prs, &nd_block);
+			}
+			else
+			{
+				parse_statement(prs, &nd_block);
+			}
+		}
+
+		token_expect_and_consume(prs, end_token, expected_end);
+	}
+
+	if (type == FUNCBODY)
+	{
+		node_add_child(&nd_block, OP_RETURN_VOID);
+	}
+	else if (type != FORBLOCK)
+	{
+		scope_block_exit(prs->sx, old_displ, old_lg);
+	}
+}
+
+/**
  *	Parse expression statement [C99 6.8.3]
  *
  *	expression-statement:
@@ -350,7 +409,7 @@ static void parse_for_statement(parser *const prs, node *const parent)
 	prs->is_in_loop = true;
 	if (prs->token == TK_L_BRACE)
 	{
-		parse_statement_compound(prs, &nd, FORBLOCK);
+		parse_compound_statement(prs, &nd, FORBLOCK);
 	}
 	else
 	{
@@ -498,7 +557,7 @@ static void parse_return_statement(parser *const prs, node *const parent)
 static void parse_create_direct_statement(parser *const prs, node *const parent)
 {
 	node nd = node_add_child(parent, OP_THREAD);
-	parse_statement_compound(prs, &nd, THREAD);
+	parse_compound_statement(prs, &nd, THREAD);
 }
 
 /**	Parse printid statement [RuC] */
@@ -729,7 +788,7 @@ void parse_statement(parser *const prs, node *const parent)
 			break;
 
 		case TK_L_BRACE:
-			parse_statement_compound(prs, parent, REGBLOCK);
+			parse_compound_statement(prs, parent, REGBLOCK);
 			break;
 
 		case TK_IF:
@@ -789,47 +848,5 @@ void parse_statement(parser *const prs, node *const parent)
 		default:
 			parse_expression_statement(prs, parent);
 			break;
-	}
-}
-
-void parse_statement_compound(parser *const prs, node *const parent, const block_t type)
-{
-	token_consume(prs); // '{' or kw_create_direct
-	node nd_block = node_add_child(parent, OP_BLOCK);
-
-	item_t old_displ = 0;
-	item_t old_lg = 0;
-
-	if (type != FUNCBODY && type != FORBLOCK)
-	{
-		scope_block_enter(prs->sx, &old_displ, &old_lg);
-	}
-
-	const token_t end_token = (type == THREAD) ? TK_EXIT_DIRECT : TK_R_BRACE;
-	if (!token_try_consume(prs, end_token))
-	{
-		while (prs->token != TK_EOF && prs->token != end_token)
-		{
-			// Почему не ловилась ошибка, если в блоке нити встретилась '}'?
-			if (is_declaration_specifier(prs))
-			{
-				parse_declaration_inner(prs, &nd_block);
-			}
-			else
-			{
-				parse_statement(prs, &nd_block);
-			}
-		}
-
-		token_expect_and_consume(prs, end_token, expected_end);
-	}
-
-	if (type == FUNCBODY)
-	{
-		node_add_child(&nd_block, OP_RETURN_VOID);
-	}
-	else if (type != FORBLOCK)
-	{
-		scope_block_exit(prs->sx, old_displ, old_lg);
 	}
 }

--- a/libs/compiler/parser_stmt.c
+++ b/libs/compiler/parser_stmt.c
@@ -694,8 +694,6 @@ static void parse_printf_statement(parser *const prs, node *const parent)
 }
 
 
-
-
 /*
  *	 __     __   __     ______   ______     ______     ______   ______     ______     ______
  *	/\ \   /\ "-.\ \   /\__  _\ /\  ___\   /\  == \   /\  ___\ /\  __ \   /\  ___\   /\  ___\


### PR DESCRIPTION
- Узел для оператора return теперь один
- Узел оператора return больше не добавляется произвольно
- Добавлен узел объявления типа [#150](https://gitlab.softcom.su/ruc/ruc/-/issues/150)
- Узлы объявлений переменных не содержат избыточной информации