### PR TITLE
Поддержка double и int64_t

### DIFF
--- a/libs/utils/hash.c
+++ b/libs/utils/hash.c
@@ -20,8 +20,12 @@
 extern item_t hash_get_key(const hash *const hs, const size_t index);
 extern size_t hash_get_amount_by_index(const hash *const hs, const size_t index);
 extern item_t hash_get_by_index(const hash *const hs, const size_t index, const size_t num);
+extern double hash_get_double_by_index(const hash *const hs, const size_t index, const size_t num);
+extern int64_t hash_get_int64_by_index(const hash *const hs, const size_t index, const size_t num);
 
 extern int hash_set_by_index(hash *const hs, const size_t index, const size_t num, const item_t value);
+extern size_t hash_set_double_by_index(hash *const hs, const size_t index, const size_t num, const double value);
+extern size_t hash_set_int64_by_index(hash *const hs, const size_t index, const size_t num, const int64_t value);
 
 extern bool hash_is_correct(const hash *const hs);
 extern int hash_clear(hash *const hs);
@@ -128,6 +132,28 @@ item_t hash_get(const hash *const hs, const item_t key, const size_t num)
 	return hash_get_by_index(hs, (size_t)index, num);
 }
 
+double hash_get_double(const hash *const hs, const item_t key, const size_t num)
+{
+	const item_t index = vector_get(hs, get_index(hs, key));
+	if (index == 0 || index == ITEM_MAX)
+	{
+		return DBL_MAX;
+	}
+
+	return hash_get_double_by_index(hs, (size_t)index, num);
+}
+
+int64_t hash_get_int64(const hash *const hs, const item_t key, const size_t num)
+{
+	const item_t index = vector_get(hs, get_index(hs, key));
+	if (index == 0 || index == ITEM_MAX)
+	{
+		return LLONG_MAX;
+	}
+
+	return hash_get_int64_by_index(hs, (size_t)index, num);
+}
+
 size_t hash_set(hash *const hs, const item_t key, const size_t num, const item_t value)
 {
 	const item_t index = vector_get(hs, get_index(hs, key));
@@ -137,4 +163,26 @@ size_t hash_set(hash *const hs, const item_t key, const size_t num, const item_t
 	}
 
 	return hash_set_by_index(hs, (size_t)index, num, value) == 0 ? (size_t)index : SIZE_MAX;
+}
+
+size_t hash_set_double(hash *const hs, const item_t key, const size_t num, const double value)
+{
+	const item_t index = vector_get(hs, get_index(hs, key));
+	if (index == 0 || index == ITEM_MAX)
+	{
+		return SIZE_MAX;
+	}
+
+	return hash_set_double_by_index(hs, (size_t)index, num, value) != DBL_MAX ? (size_t)index : SIZE_MAX;
+}
+
+size_t hash_set_int64(hash *const hs, const item_t key, const size_t num, const int64_t value)
+{
+	const item_t index = vector_get(hs, get_index(hs, key));
+	if (index == 0 || index == ITEM_MAX)
+	{
+		return SIZE_MAX;
+	}
+
+	return hash_set_int64_by_index(hs, (size_t)index, num, value) != LLONG_MAX ? (size_t)index : SIZE_MAX;
 }

--- a/libs/utils/hash.h
+++ b/libs/utils/hash.h
@@ -84,6 +84,28 @@ EXPORTED size_t hash_get_amount(const hash *const hs, const item_t key);
 EXPORTED item_t hash_get(const hash *const hs, const item_t key, const size_t num);
 
 /**
+ *	Get double value by key
+ *
+ *	@param	hs				Hash table
+ *	@param	key				Unique key
+ *	@param	num				Value number
+ *
+ *	@return	Value, @c DBL_MAX on failure
+ */
+EXPORTED double hash_get_double(const hash *const hs, const item_t key, const size_t num);
+
+/**
+ *	Get 64-bit value by key
+ *
+ *	@param	hs				Hash table
+ *	@param	key				Unique key
+ *	@param	num				Value number
+ *
+ *	@return	Value, @c LLONG_MAX on failure
+ */
+EXPORTED int64_t hash_get_int64(const hash *const hs, const item_t key, const size_t num);
+
+/**
  *	Set new value by existing key
  *
  *	@param	hs				Hash table
@@ -94,6 +116,30 @@ EXPORTED item_t hash_get(const hash *const hs, const item_t key, const size_t nu
  *	@return	Index of record, @c SIZE_MAX on failure
  */
 EXPORTED size_t hash_set(hash *const hs, const item_t key, const size_t num, const item_t value);
+
+/**
+ *	Set new double value by existing key
+ *
+ *	@param	hs				Hash table
+ *	@param	key				Unique key
+ *	@param	num				Value number
+ *	@param	value			New double value
+ *
+ *	@return	Index of record, @c SIZE_MAX on failure
+ */
+EXPORTED size_t hash_set_double(hash *const hs, const item_t key, const size_t num, const double value);
+
+/**
+ *	Set new 64-bit value by existing key
+ *
+ *	@param	hs				Hash table
+ *	@param	key				Unique key
+ *	@param	num				Value number
+ *	@param	value			New 64-bit value
+ *
+ *	@return	Index of record, @c SIZE_MAX on failure
+ */
+EXPORTED size_t hash_set_int64(hash *const hs, const item_t key, const size_t num, const int64_t value);
 
 
 /**
@@ -138,6 +184,34 @@ inline item_t hash_get_by_index(const hash *const hs, const size_t index, const 
 }
 
 /**
+ *	Get double value by index
+ *
+ *	@param	hs				Hash table
+ *	@param	index			Record index
+ *	@param	num				Value number
+ *
+ *	@return	Value, @c DBL_MAX on failure
+ */
+inline double hash_get_double_by_index(const hash *const hs, const size_t index, const size_t num)
+{
+	return num + DOUBLE_SIZE <= hash_get_amount_by_index(hs, index) ? vector_get_double(hs, index + 3 + num) : DBL_MAX;
+}
+
+/**
+ *	Get 64-bit value by index
+ *
+ *	@param	hs				Hash table
+ *	@param	index			Record index
+ *	@param	num				Value number
+ *
+ *	@return	Value, @c LLONG_MAX on failure
+ */
+inline int64_t hash_get_int64_by_index(const hash *const hs, const size_t index, const size_t num)
+{
+	return num + INT64_SIZE <= hash_get_amount_by_index(hs, index) ? vector_get_int64(hs, index + 3 + num) : LLONG_MAX;
+}
+
+/**
  *	Set new value by index
  *
  *	@param	hs				Hash table
@@ -150,6 +224,36 @@ inline item_t hash_get_by_index(const hash *const hs, const size_t index, const 
 inline int hash_set_by_index(hash *const hs, const size_t index, const size_t num, const item_t value)
 {
 	return num < hash_get_amount_by_index(hs, index) ? vector_set(hs, index + 3 + num, value) : -1;
+}
+
+/**
+ *	Set new double value by index
+ *
+ *	@param	hs				Hash table
+ *	@param	index			Record index
+ *	@param	num				Value number
+ *	@param	value			New double value
+ *
+ *	@return	Number of used elements, @c SIZE_MAX on failure
+ */
+inline size_t hash_set_double_by_index(hash *const hs, const size_t index, const size_t num, const double value)
+{
+	return num + DOUBLE_SIZE <= hash_get_amount_by_index(hs, index) ? vector_set_double(hs, index + 3 + num, value) : SIZE_MAX;
+}
+
+/**
+ *	Set new 64-bit value by index
+ *
+ *	@param	hs				Hash table
+ *	@param	index			Record index
+ *	@param	num				Value number
+ *	@param	value			New 64-bit value
+ *
+ *	@return	Number of used elements, @c SIZE_MAX on failure
+ */
+inline size_t hash_set_int64_by_index(hash *const hs, const size_t index, const size_t num, const int64_t value)
+{
+	return num + INT64_SIZE <= hash_get_amount_by_index(hs, index) ? vector_set_int64(hs, index + 3 + num, value) : SIZE_MAX;
 }
 
 

--- a/libs/utils/item.c
+++ b/libs/utils/item.c
@@ -154,14 +154,54 @@ item_t item_get_max(const item_status status)
 }
 
 
-size_t item_store_double(const double value, item_t *const stg);
+size_t item_store_double(const double value, item_t *const stg)
+{
+	int64_t temp = 0;
+	memcpy(&temp, &value, sizeof(double));
+	return item_store_int64(temp, stg);
+}
 
-size_t item_store_double_for_target(const item_status status, const double value, item_t *const stg);
+size_t item_store_double_for_target(const item_status status, const double value, item_t *const stg)
+{
+	int64_t temp = 0;
+	memcpy(&temp, &value, sizeof(double));
+	return item_store_int64_for_target(status, temp, stg);
+}
 
-double item_restore_double(const item_t *const stg);
+double item_restore_double(const item_t *const stg)
+{
+	const int64_t temp = item_restore_int64(stg);
+	if (temp == LLONG_MAX)
+	{
+		return DBL_MAX;
+	}
+
+	double value;
+	memcpy(&value, &temp, sizeof(double));
+	return value;
+}
 
 
-size_t item_store_int64(const int64_t value, item_t *const stg);
+size_t item_store_int64(const int64_t value, item_t *const stg)
+{
+#if ITEM > 32
+	return item_store_int64_for_target(item_uint64, value, stg);
+#elif ITEM > 16
+	return item_store_int64_for_target(item_uint32, value, stg);
+#elif ITEM > 8
+	return item_store_int64_for_target(item_uint16, value, stg);
+#elif ITEM >= 0
+	return item_store_int64_for_target(item_uint8, value, stg);
+#elif ITEM >= -8
+	return item_store_int64_for_target(item_int8, value, stg);
+#elif ITEM >= -16
+	return item_store_int64_for_target(item_int16, value, stg);
+#elif ITEM >= -32
+	return item_store_int64_for_target(item_int32, value, stg);
+#else
+	return item_store_int64_for_target(item_int64, value, stg);
+#endif
+}
 
 size_t item_store_int64_for_target(const item_status status, const int64_t value, item_t *const stg);
 

--- a/libs/utils/item.c
+++ b/libs/utils/item.c
@@ -15,7 +15,6 @@
  */
 
 #include "item.h"
-#include <stddef.h>
 #include <string.h>
 
 
@@ -153,6 +152,21 @@ item_t item_get_max(const item_status status)
 			return 0;
 	}
 }
+
+
+size_t item_store_double(const double value, item_t *const stg);
+
+size_t item_store_double_for_target(const item_status status, const double value, item_t *const stg);
+
+double item_restore_double(const item_t *const stg);
+
+
+size_t item_store_int64(const int64_t value, item_t *const stg);
+
+size_t item_store_int64_for_target(const item_status status, const int64_t value, item_t *const stg);
+
+int64_t item_restore_int64(const item_t *const stg);
+
 
 bool item_check_var(const item_status status, const item_t var)
 {

--- a/libs/utils/item.c
+++ b/libs/utils/item.c
@@ -224,14 +224,14 @@ size_t item_store_int64_for_target(const item_status status, const int64_t value
 							? 4
 							: 8;
 
-	if (abs(ITEM) < 8 * size)
+	if (abs(ITEM) <= 32 / size)
 	{
-		size = ceil((double)abs(ITEM) / 8);
+		size = (size_t)pow(2, ceil(log2(abs(ITEM))));
 	}
 
 	const size_t shift = 64 / size;
 	int64_t mask = 0x00000000000000FF;
-	for (size_t i = 16; i < shift; i *= 2)
+	for (size_t i = 8; i < shift; i *= 2)
 	{
 		mask = (mask << i) | mask;
 	}

--- a/libs/utils/item.h
+++ b/libs/utils/item.h
@@ -17,8 +17,10 @@
 #pragma once
 
 #include <inttypes.h>
+#include <float.h>
 #include <limits.h>
 #include <stdbool.h>
+#include <stddef.h>
 #include <stdint.h>
 #include "dll.h"
 #include "workspace.h"
@@ -120,6 +122,69 @@ EXPORTED item_t item_get_min(const item_status status);
  *	@return	Target @c ITEM_MAX
  */
 EXPORTED item_t item_get_max(const item_status status);
+
+
+/**
+ *	Store double value into item array
+ *
+ *	@param	value		Double variable
+ *	@param	stg			Item array
+ *
+ *	@return	Number of used elements, @c SIZE_MAX on failure
+ */
+EXPORTED size_t item_store_double(const double value, item_t *const stg);
+
+/**
+ *	Store double value into target item array
+ *
+ *	@param	status		Item status
+ *	@param	value		Double variable
+ *	@param	stg			Item array
+ *
+ *	@return	Number of used elements, @c SIZE_MAX on failure
+ */
+EXPORTED size_t item_store_double_for_target(const item_status status, const double value, item_t *const stg);
+
+/**
+ *	Restore double value from item array
+ *
+ *	@param	stg			Item array
+ *
+ *	@return	Restored value, @c DBL_MAX on failure
+ */
+EXPORTED double item_restore_double(const item_t *const stg);
+
+
+/**
+ *	Store 64-bit value into item array
+ *
+ *	@param	value		64-bit variable
+ *	@param	stg			Item array
+ *
+ *	@return	Number of used elements, @c SIZE_MAX on failure
+ */
+EXPORTED size_t item_store_int64(const int64_t value, item_t *const stg);
+
+/**
+ *	Store 64-bit value into target item array
+ *
+ *	@param	status		Item status
+ *	@param	value		64-bit variable
+ *	@param	stg			Item array
+ *
+ *	@return	Number of used elements, @c SIZE_MAX on failure
+ */
+EXPORTED size_t item_store_int64_for_target(const item_status status, const int64_t value, item_t *const stg);
+
+/**
+ *	Restore 64-bit value from item array
+ *
+ *	@param	stg			Item array
+ *
+ *	@return	Restored value, @c LLONG_MAX on failure
+ */
+EXPORTED int64_t item_restore_int64(const item_t *const stg);
+
 
 /**
  *	Check that variable is not out of range

--- a/libs/utils/item.h
+++ b/libs/utils/item.h
@@ -72,6 +72,9 @@
 	#define PRIitem PRIi64
 #endif
 
+#define DOUBLE_SIZE (sizeof(double) / sizeof(ITEM_TYPE))
+#define INT64_SIZE (sizeof(int64_t) / sizeof(ITEM_TYPE))
+
 
 #ifdef __cplusplus
 extern "C" {

--- a/libs/utils/map.h
+++ b/libs/utils/map.h
@@ -16,8 +16,6 @@
 
 #pragma once
 
-#include <stdbool.h>
-#include <stddef.h>
 #include "dll.h"
 #include "item.h"
 #include "uniio.h"

--- a/libs/utils/stack.c
+++ b/libs/utils/stack.c
@@ -20,8 +20,16 @@
 extern stack stack_create(const size_t alloc);
 
 extern int stack_push(stack *const stk, const item_t value);
+extern int stack_push_double(stack *const stk, const double value);
+extern int stack_push_int64(stack *const stk, const int64_t value);
+
 extern item_t stack_pop(stack *const stk);
+extern double stack_pop_double(stack *const stk);
+extern int64_t stack_pop_int64(stack *const stk);
+
 extern item_t stack_peek(const stack *const stk);
+extern double stack_peek_double(const stack *const stk);
+extern int64_t stack_peek_int64(const stack *const stk);
 
 extern int stack_reset(stack *const stk);
 extern size_t stack_size(const stack *const stk);

--- a/libs/utils/stack.h
+++ b/libs/utils/stack.h
@@ -54,6 +54,33 @@ inline int stack_push(stack *const stk, const item_t value)
 }
 
 /**
+ *	Push new double value
+ *
+ *	@param	stk				Stack structure
+ *	@param	value			Double value
+ *
+ *	@return	@c 0 on success, @c -1 on failure
+ */
+inline int stack_push_double(stack *const stk, const double value)
+{
+	return vector_add_double(stk, value) != SIZE_MAX ? 0 : -1;
+}
+
+/**
+ *	Push new 64-bit value
+ *
+ *	@param	stk				Stack structure
+ *	@param	value			64-bit value
+ *
+ *	@return	@c 0 on success, @c -1 on failure
+ */
+inline int stack_push_int64(stack *const stk, const int64_t value)
+{
+	return vector_add_int64(stk, value) != SIZE_MAX ? 0 : -1;
+}
+
+
+/**
  *	Pop value
  *
  *	@param	stk				Stack structure
@@ -66,6 +93,31 @@ inline item_t stack_pop(stack *const stk)
 }
 
 /**
+ *	Pop double value
+ *
+ *	@param	stk				Stack structure
+ *
+ *	@return	Value, @c DBL_MAX on failure
+ */
+inline double stack_pop_double(stack *const stk)
+{
+	return vector_remove_double(stk);
+}
+
+/**
+ *	Pop 64-bit value
+ *
+ *	@param	stk				Stack structure
+ *
+ *	@return	Value, @c LLONG_MAX on failure
+ */
+inline int64_t stack_pop_int64(stack *const stk)
+{
+	return vector_remove_int64(stk);
+}
+
+
+/**
  *	Peek value
  *
  *	@param	stk				Stack structure
@@ -75,6 +127,29 @@ inline item_t stack_pop(stack *const stk)
 inline item_t stack_peek(const stack *const stk)
 {
 	return vector_get(stk, vector_size(stk) - 1);
+}
+
+/**
+ *	Peek double value
+ *
+ *	@param	stk				Stack structure
+ *
+ *	@return	Value, @c DBL_MAX on failure
+ */
+inline double stack_peek_double(const stack *const stk)
+{
+	return vector_get_double(stk, vector_size(stk) - DOUBLE_SIZE);
+}
+/**
+ *	Peek 64-bit value
+ *
+ *	@param	stk				Stack structure
+ *
+ *	@return	Value, @c LLONG_MAX on failure
+ */
+inline int64_t stack_peek_int64(const stack *const stk)
+{
+	return vector_get_int64(stk, vector_size(stk) - INT64_SIZE);
 }
 
 

--- a/libs/utils/tree.c
+++ b/libs/utils/tree.c
@@ -278,9 +278,9 @@ int node_add_arg(const node *const nd, const item_t arg)
 	{
 		return -2;
 	}
-
-	ref_set_argc(nd, (item_t)node_get_argc(nd) + 1);	
+	
 	vector_add(nd->tree, arg);
+	ref_set_argc(nd, (item_t)node_get_argc(nd) + 1);
 
 	return 0;
 }
@@ -350,7 +350,7 @@ node node_insert(const node *const nd, const item_t type, const size_t argc)
 	node child = { nd->tree, vector_add(nd->tree, 1) };
 	vector_add(nd->tree, nd->index);
 	vector_add(nd->tree, argc);
-	vector_resize(nd->tree, vector_size(nd->tree) + argc);
+	vector_increase(nd->tree, argc);
 
 	vector_set(nd->tree, reference, (item_t)child.index);
 	ref_set_next(nd, to_negative(child.index));

--- a/libs/utils/tree.c
+++ b/libs/utils/tree.c
@@ -180,6 +180,16 @@ item_t node_get_arg(const node *const nd, const size_t index)
 	return index < node_get_argc(nd) ? vector_get(nd->tree, ref_get_argc(nd) + 1 + index) : ITEM_MAX;
 }
 
+double node_get_arg_double(const node *const nd, const size_t index)
+{
+	return index + DOUBLE_SIZE <= node_get_argc(nd) ? vector_get_double(nd->tree, ref_get_argc(nd) + 1 + index) : DBL_MAX;
+}
+
+int64_t node_get_arg_int64(const node *const nd, const size_t index)
+{
+	return index + INT64_SIZE <= node_get_argc(nd) ? vector_get_int64(nd->tree, ref_get_argc(nd) + 1 + index) : LLONG_MAX;
+}
+
 size_t node_get_amount(const node *const nd)
 {
 	return node_is_correct(nd) ? (size_t)vector_get(nd->tree, ref_get_amount(nd)) : 0;
@@ -285,6 +295,42 @@ int node_add_arg(const node *const nd, const item_t arg)
 	return 0;
 }
 
+int node_add_arg_double(const node *const nd, const double arg)
+{
+	if (!node_is_correct(nd))
+	{
+		return -1;
+	}
+
+	if (node_get_amount(nd) != 0)
+	{
+		return -2;
+	}
+	
+	vector_add_double(nd->tree, arg);
+	ref_set_argc(nd, (item_t)node_get_argc(nd) + DOUBLE_SIZE);
+
+	return 0;
+}
+
+int node_add_arg_int64(const node *const nd, const int64_t arg)
+{
+	if (!node_is_correct(nd))
+	{
+		return -1;
+	}
+
+	if (node_get_amount(nd) != 0)
+	{
+		return -2;
+	}
+	
+	vector_add_int64(nd->tree, arg);
+	ref_set_argc(nd, (item_t)node_get_argc(nd) + INT64_SIZE);
+
+	return 0;
+}
+
 int node_set_arg(const node *const nd, const size_t index, const item_t arg)
 {
 	if (index >= node_get_argc(nd))
@@ -293,6 +339,26 @@ int node_set_arg(const node *const nd, const size_t index, const item_t arg)
 	}
 
 	return vector_set(nd->tree, ref_get_argc(nd) + 1 + index, arg);
+}
+
+size_t node_set_arg_double(const node *const nd, const size_t index, const double arg)
+{
+	if (index + DOUBLE_SIZE > node_get_argc(nd))
+	{
+		return SIZE_MAX;
+	}
+
+	return vector_set_double(nd->tree, ref_get_argc(nd) + 1 + index, arg);
+}
+
+size_t node_set_arg_int64(const node *const nd, const size_t index, const int64_t arg)
+{
+	if (index + INT64_SIZE > node_get_argc(nd))
+	{
+		return SIZE_MAX;
+	}
+
+	return vector_set_int64(nd->tree, ref_get_argc(nd) + 1 + index, arg);
 }
 
 

--- a/libs/utils/tree.c
+++ b/libs/utils/tree.c
@@ -48,13 +48,19 @@ static inline size_t ref_get_next(const node *const nd)
 
 static inline size_t ref_get_amount(const node *const nd)
 {
-	return nd->index + 1 + (size_t)vector_get(nd->tree, nd->index);
+	return nd->index;
 }
 
 static inline size_t ref_get_children(const node *const nd)
 {
-	return nd->index + 2 + (size_t)vector_get(nd->tree, nd->index);
+	return nd->index + 1;
 }
+
+static inline size_t ref_get_argc(const node *const nd)
+{
+	return nd->index + 2;
+}
+
 
 static inline int ref_set_next(const node *const nd, const item_t value)
 {
@@ -65,10 +71,17 @@ static inline int ref_set_amount(const node *const nd, const item_t value)
 {
 	return vector_set(nd->tree, ref_get_amount(nd), value);
 }
+
 static inline int ref_set_children(const node *const nd, const item_t value)
 {
 	return vector_set(nd->tree, ref_get_children(nd), value);
 }
+
+static inline int ref_set_argc(const node *const nd, const item_t value)
+{
+	return vector_set(nd->tree, ref_get_argc(nd), value);
+}
+
 
 static inline node node_broken()
 {
@@ -117,10 +130,10 @@ node node_get_root(vector *const tree)
 	if (size == 0)
 	{
 		vector_add(tree, 0);
-		vector_add(tree, 0);
 		vector_add(tree, 5);
+		vector_add(tree, 0);
 	}
-	else if (size == SIZE_MAX || size < 3 || vector_get(tree, 0) < 0)
+	else if (size == SIZE_MAX || size < 3 || vector_get(tree, 2) < 0)
 	{
 		return node_broken();
 	}
@@ -159,12 +172,12 @@ item_t node_get_type(const node *const nd)
 
 size_t node_get_argc(const node *const nd)
 {
-	return node_is_correct(nd) ? (size_t)vector_get(nd->tree, nd->index) : 0;
+	return node_is_correct(nd) ? (size_t)vector_get(nd->tree, ref_get_argc(nd)) : 0;
 }
 
 item_t node_get_arg(const node *const nd, const size_t index)
 {
-	return index < node_get_argc(nd) ? vector_get(nd->tree, nd->index + 1 + index) : ITEM_MAX;
+	return index < node_get_argc(nd) ? vector_get(nd->tree, ref_get_argc(nd) + 1 + index) : ITEM_MAX;
 }
 
 size_t node_get_amount(const node *const nd)
@@ -266,21 +279,20 @@ int node_add_arg(const node *const nd, const item_t arg)
 		return -2;
 	}
 
-	ref_set_amount(nd, arg);
+	ref_set_argc(nd, (item_t)node_get_argc(nd) + 1);	
+	vector_add(nd->tree, arg);
 
-	vector_add(nd->tree, 0);
-	vector_set(nd->tree, nd->index, vector_get(nd->tree, nd->index) + 1);
 	return 0;
 }
 
 int node_set_arg(const node *const nd, const size_t index, const item_t arg)
 {
-	if (!node_is_correct(nd) || index >= node_get_argc(nd))
+	if (index >= node_get_argc(nd))
 	{
 		return -1;
 	}
 
-	return vector_set(nd->tree, nd->index + 1 + index, arg);
+	return vector_set(nd->tree, ref_get_argc(nd) + 1 + index, arg);
 }
 
 
@@ -304,7 +316,7 @@ size_t node_save(const node *const nd)
 
 node node_load(vector *const tree, const size_t index)
 {
-	if (!vector_is_correct(tree) || vector_get(tree, index) >= (item_t)(vector_size(tree) - index - 2))
+	if (!vector_is_correct(tree) || vector_get(tree, index + 2) >= (item_t)(vector_size(tree) - index - 2))
 	{
 		return node_broken();
 	}
@@ -335,10 +347,10 @@ node node_insert(const node *const nd, const item_t type, const size_t argc)
 
 	vector_add(nd->tree, vector_get(nd->tree, ref_get_next(nd)));
 	vector_add(nd->tree, type);
-	node child = { nd->tree, vector_add(nd->tree, argc) };
-	vector_resize(nd->tree, vector_size(nd->tree) + argc);
-	vector_add(nd->tree, 1);
+	node child = { nd->tree, vector_add(nd->tree, 1) };
 	vector_add(nd->tree, nd->index);
+	vector_add(nd->tree, argc);
+	vector_resize(nd->tree, vector_size(nd->tree) + argc);
 
 	vector_set(nd->tree, reference, (item_t)child.index);
 	ref_set_next(nd, to_negative(child.index));
@@ -439,7 +451,7 @@ int node_remove(node *const nd)
 		ref_set_amount(&parent, (item_t)node_get_amount(&parent) - 1);
 	}
 
-	if (node_get_amount(nd) == 0 && ref_get_children(nd) == vector_size(nd->tree) - 1)
+	if (node_get_amount(nd) == 0 && (ref_get_argc(nd) + node_get_argc(nd)) == vector_size(nd->tree) - 1)
 	{
 		vector_resize(nd->tree, ref_get_next(nd));
 	}

--- a/libs/utils/tree.h
+++ b/libs/utils/tree.h
@@ -89,6 +89,26 @@ EXPORTED size_t node_get_argc(const node *const nd);
 EXPORTED item_t node_get_arg(const node *const nd, const size_t index);
 
 /**
+ *	Get double argument from node by index
+ *
+ *	@param	nd			Node structure
+ *	@param	index		Argument number
+ *
+ *	@return	Argument, @c DBL_MAX on failure
+ */
+EXPORTED double node_get_arg_double(const node *const nd, const size_t index);
+
+/**
+ *	Get 64-bit argument from node by index
+ *
+ *	@param	nd			Node structure
+ *	@param	index		Argument number
+ *
+ *	@return	Argument, @c LLONG_MAX on failure
+ */
+EXPORTED int64_t node_get_arg_int64(const node *const nd, const size_t index);
+
+/**
  *	Get amount of children
  *
  *	@param	nd			Node structure
@@ -152,15 +172,61 @@ EXPORTED int node_set_type(const node *const nd, const item_t type);
 EXPORTED int node_add_arg(const node *const nd, const item_t arg);
 
 /**
+ *	Add new node double argument
+ *
+ *	@param	nd			Node structure
+ *	@param	arg			Node double argument
+ *
+ *	@return	@c  0 on success,
+ *			@c -1 on failure,
+ *			@c -2 on node with children
+ */
+EXPORTED int node_add_arg_double(const node *const nd, const double arg);
+
+/**
+ *	Add new node 64-bit argument
+ *
+ *	@param	nd			Node structure
+ *	@param	arg			Node 64-bit argument
+ *
+ *	@return	@c  0 on success,
+ *			@c -1 on failure,
+ *			@c -2 on node with children
+ */
+EXPORTED int node_add_arg_int64(const node *const nd, const int64_t arg);
+
+/**
  *	Set node argument by index
  *
  *	@param	nd			Node structure
  *	@param	index		Argument number
  *	@param	arg			Node argument
  *
- *	@return	@c  0 on success, @c -1 on failure
+ *	@return	@c 0 on success, @c -1 on failure
  */
 EXPORTED int node_set_arg(const node *const nd, const size_t index, const item_t arg);
+
+/**
+ *	Set node double argument by index
+ *
+ *	@param	nd			Node structure
+ *	@param	index		Argument number
+ *	@param	arg			Node double argument
+ *
+ *	@return	Number of used elements, @c SIZE_MAX on failure
+ */
+EXPORTED size_t node_set_arg_double(const node *const nd, const size_t index, const double arg);
+
+/**
+ *	Set node 64-bit argument by index
+ *
+ *	@param	nd			Node structure
+ *	@param	index		Argument number
+ *	@param	arg			Node 64-bit argument
+ *
+ *	@return	Number of used elements, @c SIZE_MAX on failure
+ */
+EXPORTED size_t node_set_arg_int64(const node *const nd, const size_t index, const int64_t arg);
 
 
 /**

--- a/libs/utils/vector.c
+++ b/libs/utils/vector.c
@@ -19,6 +19,10 @@
 #include <string.h>
 
 
+static const size_t DOUBLE_SIZE = sizeof(double) / sizeof(item_t);
+static const size_t INT64_SIZE = sizeof(int64_t) / sizeof(item_t);
+
+
 static int change_size(vector *const vec, const size_t size)
 {
 	if (size > vec->size_alloc)
@@ -65,11 +69,6 @@ vector vector_create(const size_t alloc)
 }
 
 
-int vector_increase(vector *const vec, const size_t size)
-{
-	return vector_is_correct(vec) ? change_size(vec, vec->size + size) : -1;
-}
-
 size_t vector_add(vector *const vec, const item_t value)
 {
 	if (!vector_is_correct(vec) || change_size(vec, vec->size + 1))
@@ -80,6 +79,29 @@ size_t vector_add(vector *const vec, const item_t value)
 	vec->array[vec->size - 1] = value;
 	return vec->size - 1;
 }
+
+size_t vector_add_double(vector *const vec, const double value)
+{
+	if (!vector_is_correct(vec) || change_size(vec, vec->size + DOUBLE_SIZE))
+	{
+		return SIZE_MAX;
+	}
+
+	item_store_double(value, &vec->array[vec->size - DOUBLE_SIZE]);
+	return vec->size - DOUBLE_SIZE;
+}
+
+size_t vector_add_int64(vector *const vec, const int64_t value)
+{
+	if (!vector_is_correct(vec) || change_size(vec, vec->size + INT64_SIZE))
+	{
+		return SIZE_MAX;
+	}
+
+	item_store_int64(value, &vec->array[vec->size - DOUBLE_SIZE]);
+	return vec->size - INT64_SIZE;
+}
+
 
 int vector_set(vector *const vec, const size_t index, const item_t value)
 {
@@ -92,6 +114,27 @@ int vector_set(vector *const vec, const size_t index, const item_t value)
 	return 0;
 }
 
+size_t vector_set_double(vector *const vec, const size_t index, const double value)
+{
+	if (!vector_is_correct(vec) || index + DOUBLE_SIZE > vec->size)
+	{
+		return SIZE_MAX;
+	}
+
+	return item_store_double(value, &vec->array[index]);
+}
+
+size_t vector_set_int64(vector *const vec, const size_t index, const int64_t value)
+{
+	if (!vector_is_correct(vec) || index + INT64_SIZE > vec->size)
+	{
+		return SIZE_MAX;
+	}
+
+	return item_store_int64(value, &vec->array[index]);
+}
+
+
 item_t vector_get(const vector *const vec, const size_t index)
 {
 	if (!vector_is_correct(vec) || index >= vec->size)
@@ -101,6 +144,27 @@ item_t vector_get(const vector *const vec, const size_t index)
 
 	return vec->array[index];
 }
+
+double vector_get_double(const vector *const vec, const size_t index)
+{
+	if (!vector_is_correct(vec) || index + DOUBLE_SIZE > vec->size)
+	{
+		return DBL_MAX;
+	}
+
+	return item_restore_double(&vec->array[index]);
+}
+
+int64_t vector_get_int64(const vector *const vec, const size_t index)
+{
+	if (!vector_is_correct(vec) || index + INT64_SIZE > vec->size)
+	{
+		return LLONG_MAX;
+	}
+
+	return item_restore_int64(&vec->array[index]);
+}
+
 
 item_t vector_remove(vector *const vec)
 {
@@ -112,6 +176,33 @@ item_t vector_remove(vector *const vec)
 	return vec->array[--vec->size];
 }
 
+double vector_remove_double(vector *const vec)
+{
+	if (!vector_is_correct(vec) || vec->size < DOUBLE_SIZE)
+	{
+		return DBL_MAX;
+	}
+
+	vec->size -= DOUBLE_SIZE;
+	return item_restore_double(&vec->array[vec->size]);
+}
+
+int64_t vector_remove_int64(vector *const vec)
+{
+	if (!vector_is_correct(vec) || vec->size < INT64_SIZE)
+	{
+		return LLONG_MAX;
+	}
+
+	vec->size -= INT64_SIZE;
+	return item_restore_int64(&vec->array[vec->size]);
+}
+
+
+int vector_increase(vector *const vec, const size_t size)
+{
+	return vector_is_correct(vec) ? change_size(vec, vec->size + size) : -1;
+}
 
 int vector_resize(vector *const vec, const size_t size)
 {

--- a/libs/utils/vector.c
+++ b/libs/utils/vector.c
@@ -19,10 +19,6 @@
 #include <string.h>
 
 
-static const size_t DOUBLE_SIZE = sizeof(double) / sizeof(item_t);
-static const size_t INT64_SIZE = sizeof(int64_t) / sizeof(item_t);
-
-
 static int change_size(vector *const vec, const size_t size)
 {
 	if (size > vec->size_alloc)

--- a/libs/utils/vector.h
+++ b/libs/utils/vector.h
@@ -17,7 +17,6 @@
 #pragma once
 
 #include <stdbool.h>
-#include <stddef.h>
 #include "dll.h"
 #include "item.h"
 
@@ -46,16 +45,6 @@ EXPORTED vector vector_create(const size_t alloc);
 
 
 /**
- *	Increase vector size
- *
- *	@param	vec				Vector structure
- *	@param	size			Size to increase
- *
- *	@return	@c 0 on success, @c -1 on failure
- */
-EXPORTED int vector_increase(vector *const vec, const size_t size);
-
-/**
  *	Add new value
  *
  *	@param	vec				Vector structure
@@ -64,6 +53,27 @@ EXPORTED int vector_increase(vector *const vec, const size_t size);
  *	@return	Index, @c SIZE_MAX on failure
  */
 EXPORTED size_t vector_add(vector *const vec, const item_t value);
+
+/**
+ *	Add new double value
+ *
+ *	@param	vec				Vector structure
+ *	@param	value			Double value
+ *
+ *	@return	Index, @c SIZE_MAX on failure
+ */
+EXPORTED size_t vector_add_double(vector *const vec, const double value);
+
+/**
+ *	Add new 64-bit value
+ *
+ *	@param	vec				Vector structure
+ *	@param	value			64-bit value
+ *
+ *	@return	Index, @c SIZE_MAX on failure
+ */
+EXPORTED size_t vector_add_int64(vector *const vec, const int64_t value);
+
 
 /**
  *	Set new value
@@ -77,6 +87,29 @@ EXPORTED size_t vector_add(vector *const vec, const item_t value);
 EXPORTED int vector_set(vector *const vec, const size_t index, const item_t value);
 
 /**
+ *	Set new double value
+ *
+ *	@param	vec				Vector structure
+ *	@param	index			Index
+ *	@param	value			New double value
+ *
+ *	@return	Number of used elements, @c SIZE_MAX on failure
+ */
+EXPORTED size_t vector_set_double(vector *const vec, const size_t index, const double value);
+
+/**
+ *	Set new 64-bit value
+ *
+ *	@param	vec				Vector structure
+ *	@param	index			Index
+ *	@param	value			New 64-bit value
+ *
+ *	@return	Number of used elements, @c SIZE_MAX on failure
+ */
+EXPORTED size_t vector_set_int64(vector *const vec, const size_t index, const int64_t value);
+
+
+/**
  *	Get value
  *
  *	@param	vec				Vector structure
@@ -87,6 +120,27 @@ EXPORTED int vector_set(vector *const vec, const size_t index, const item_t valu
 EXPORTED item_t vector_get(const vector *const vec, const size_t index);
 
 /**
+ *	Get double value
+ *
+ *	@param	vec				Vector structure
+ *	@param	index			Index
+ *
+ *	@return	Value, @c DBL_MAX on failure
+ */
+EXPORTED double vector_get_double(const vector *const vec, const size_t index);
+
+/**
+ *	Get 64-bit value
+ *
+ *	@param	vec				Vector structure
+ *	@param	index			Index
+ *
+ *	@return	Value, @c LLONG_MAX on failure
+ */
+EXPORTED int64_t vector_get_int64(const vector *const vec, const size_t index);
+
+
+/**
  *	Remove last value
  *
  *	@param	vec				Vector structure
@@ -95,6 +149,34 @@ EXPORTED item_t vector_get(const vector *const vec, const size_t index);
  */
 EXPORTED item_t vector_remove(vector *const vec);
 
+/**
+ *	Remove last double value
+ *
+ *	@param	vec				Vector structure
+ *
+ *	@return	Deleted value, @c DBL_MAX on failure
+ */
+EXPORTED double vector_remove_double(vector *const vec);
+
+/**
+ *	Remove last 64-bit value
+ *
+ *	@param	vec				Vector structure
+ *
+ *	@return	Deleted value, @c LLONG_MAX on failure
+ */
+EXPORTED int64_t vector_remove_int64(vector *const vec);
+
+
+/**
+ *	Increase vector size
+ *
+ *	@param	vec				Vector structure
+ *	@param	size			Size to increase
+ *
+ *	@return	@c 0 on success, @c -1 on failure
+ */
+EXPORTED int vector_increase(vector *const vec, const size_t size);
 
 /**
  *	Change vector size

--- a/libs/utils/vector.h
+++ b/libs/utils/vector.h
@@ -16,7 +16,6 @@
 
 #pragma once
 
-#include <stdbool.h>
 #include "dll.h"
 #include "item.h"
 


### PR DESCRIPTION
Добавлена поддержка типов `double` и `int64_t` в библиотеки: `item`, `vector`, `stack`, `hash`, `tree`. Изменена структура узла дерева.  