### PR TITLE
Небольшие изменения в объявлении и вызове функций и работа с файлами

### DIFF
--- a/libs/compiler/llvmgen.c
+++ b/libs/compiler/llvmgen.c
@@ -84,6 +84,11 @@ static void expression(information *const info, node *const nd);
 static void block(information *const info, node *const nd);
 
 
+static const char * get_func_name(const syntax *const sx, const size_t index)
+{
+	return repr_get_name(sx, ident_get_repr(sx, index));
+}
+
 static item_t array_get_type(information *const info, const item_t array_type)
 {
 	item_t type = array_type;
@@ -1092,6 +1097,7 @@ static void expression(information *const info, node *const nd)
 			node_set_next(nd);
 
 			const item_t type_ref = node_get_arg(nd, 0);
+			const size_t func_ref = (size_t)node_get_arg(nd, 2);
 			const size_t args = type_function_get_parameter_amount(info->sx, type_ref);
 			if (args > MAX_FUNCTION_ARGS)
 			{
@@ -1130,7 +1136,7 @@ static void expression(information *const info, node *const nd)
 			}
 			uni_printf(info->sx->io, " call ");
 			type_to_io(info, func_type);
-			uni_printf(info->sx->io, " @func%" PRIitem "(", type_ref);
+			uni_printf(info->sx->io, " @%s(", get_func_name(info->sx, func_ref));
 
 			for (size_t i = 0; i < args; i++)
 			{
@@ -1627,20 +1633,12 @@ static int codegen(information *const info)
 				const item_t func_type = ident_get_type(info->sx, ref_ident);
 				const item_t ret_type = type_function_get_return_type(info->sx, func_type);
 				const size_t parameters = type_function_get_parameter_amount(info->sx, func_type);
-				const bool is_main = ident_get_prev(info->sx, ref_ident) == TK_MAIN;
 				info->was_dynamic = false;
 				node_set_next(&root);
 
 				uni_printf(info->sx->io, "define ");
 				type_to_io(info, ret_type);
-				if (is_main)
-				{
-					uni_printf(info->sx->io, " @main(");
-				}
-				else
-				{
-					uni_printf(info->sx->io, " @func%" PRIitem "(", ident_get_type(info->sx, ref_ident));
-				}
+				uni_printf(info->sx->io, " @%s(", get_func_name(info->sx, ref_ident));
 
 				for (size_t i = 0; i < parameters; i++)
 				{

--- a/libs/compiler/llvmgen.c
+++ b/libs/compiler/llvmgen.c
@@ -1711,6 +1711,7 @@ static int codegen(information *const info)
 							"i32, [20 x i8] }\n");
 						uni_printf(info->sx->io, "%%struct._IO_marker = type { %%struct._IO_marker*, %%struct._IO_FILE*, i32 }\n");
 						uni_printf(info->sx->io, "declare %%struct._IO_FILE* @fopen(i8*, i8*)\n");
+						uni_printf(info->sx->io, "declare i32 @fclose(%%struct._IO_FILE*)\n");
 					}
 
 					return 0;

--- a/libs/compiler/llvmgen.c
+++ b/libs/compiler/llvmgen.c
@@ -1627,16 +1627,17 @@ static int codegen(information *const info)
 				const item_t func_type = ident_get_type(info->sx, ref_ident);
 				const item_t ret_type = type_function_get_return_type(info->sx, func_type);
 				const size_t parameters = type_function_get_parameter_amount(info->sx, func_type);
+				const bool is_main = ident_get_prev(info->sx, ref_ident) == TK_MAIN;
 				info->was_dynamic = false;
 
-				if (ident_get_prev(info->sx, ref_ident) == TK_MAIN)
+				uni_printf(info->sx->io, "define ");
+				type_to_io(info, ret_type);
+				if (is_main)
 				{
-					uni_printf(info->sx->io, "define i32 @main(");
+					uni_printf(info->sx->io, " @main(");
 				}
 				else
 				{
-					uni_printf(info->sx->io, "define ");
-					type_to_io(info, ret_type);
 					uni_printf(info->sx->io, " @func%" PRIitem "(", ident_get_type(info->sx, ref_ident));
 				}
 

--- a/libs/compiler/llvmgen.c
+++ b/libs/compiler/llvmgen.c
@@ -30,8 +30,7 @@
 static const size_t HASH_TABLE_SIZE = 1024;
 static const size_t IS_STATIC = 0;
 static const size_t DIMENSION_LOW_BORDER = 1;
-static const size_t OP_SLICE_DIMENSION = 2;
-static const size_t MAX_DIMENSIONS = SIZE_MAX - 2;
+static const size_t MAX_DIMENSIONS = SIZE_MAX - 2;		// Из-за OP_SLICE
 
 
 typedef enum ANSWER

--- a/libs/compiler/llvmgen.c
+++ b/libs/compiler/llvmgen.c
@@ -1629,6 +1629,7 @@ static int codegen(information *const info)
 				const size_t parameters = type_function_get_parameter_amount(info->sx, func_type);
 				const bool is_main = ident_get_prev(info->sx, ref_ident) == TK_MAIN;
 				info->was_dynamic = false;
+				node_set_next(&root);
 
 				uni_printf(info->sx->io, "define ");
 				type_to_io(info, ret_type);
@@ -1652,8 +1653,9 @@ static int codegen(information *const info)
 
 				for (size_t i = 0; i < parameters; i++)
 				{
-					const item_t param_displ = ident_get_displ(info->sx, ref_ident + 4 * (i + 1));
-					const item_t param_type = type_function_get_parameter_type(info->sx, func_type, i);
+					const item_t param_displ = ident_get_displ(info->sx, (size_t)node_get_arg(&root, 0));
+					const item_t param_type = ident_get_type(info->sx, (size_t)node_get_arg(&root, 0));
+					node_set_next(&root);
 
 					uni_printf(info->sx->io, " %%var.%" PRIitem " = alloca ", param_displ);
 					type_to_io(info, param_type);
@@ -1666,7 +1668,6 @@ static int codegen(information *const info)
 					uni_printf(info->sx->io, "* %%var.%" PRIitem ", align 4\n", param_displ);
 				}
 
-				node_set_next(&root);
 				block(info, &root);
 
 				if (type_is_void(ret_type))

--- a/libs/compiler/llvmgen.c
+++ b/libs/compiler/llvmgen.c
@@ -1157,6 +1157,22 @@ static void expression(information *const info, node *const nd)
 			uni_printf(info->sx->io, ")\n");
 		}
 		break;
+		case OP_STRING:
+		{
+			// const size_t index = (size_t)node_get_arg(nd, 2);
+			// const size_t string_length = strings_length(info->sx, index);
+
+			// uni_printf(info->sx->io, "i8* getelementptr inbounds "
+			// 	"([%zu x i8], [%zu x i8]* @.str%zu, i32 0, i32 0"
+			// 	, string_length + 1
+			// 	, string_length + 1
+			// 	, index);
+			
+			info->answer_reg = -1;
+			info->answer_kind = AREG;
+			node_set_next(nd);
+		}
+			break;
 		case OP_SELECT:
 			node_set_next(nd);
 			break;
@@ -1781,7 +1797,7 @@ int encode_to_llvm(const workspace *const ws, syntax *const sx)
 	{
 		return -1;
 	}
-	// tables_and_tree("tree.txt", &(sx->identifiers), &(sx->types), &(sx->tree));
+	tables_and_tree("tree.txt", &(sx->identifiers), &(sx->types), &(sx->tree));
 
 	information info;
 	info.sx = sx;

--- a/libs/compiler/llvmgen.c
+++ b/libs/compiler/llvmgen.c
@@ -1711,6 +1711,7 @@ static int codegen(information *const info)
 							"i32, [20 x i8] }\n");
 						uni_printf(info->sx->io, "%%struct._IO_marker = type { %%struct._IO_marker*, %%struct._IO_FILE*, i32 }\n");
 						uni_printf(info->sx->io, "declare %%struct._IO_FILE* @fopen(i8*, i8*)\n");
+						uni_printf(info->sx->io, "declare i32 @fgetc(%%struct._IO_FILE*)\n");
 						uni_printf(info->sx->io, "declare i32 @fclose(%%struct._IO_FILE*)\n");
 					}
 

--- a/libs/compiler/llvmgen.c
+++ b/libs/compiler/llvmgen.c
@@ -1797,7 +1797,7 @@ int encode_to_llvm(const workspace *const ws, syntax *const sx)
 	{
 		return -1;
 	}
-	tables_and_tree("tree.txt", &(sx->identifiers), &(sx->types), &(sx->tree));
+	// tables_and_tree("tree.txt", &(sx->identifiers), &(sx->types), &(sx->tree));
 
 	information info;
 	info.sx = sx;

--- a/libs/compiler/llvmgen.c
+++ b/libs/compiler/llvmgen.c
@@ -1653,8 +1653,9 @@ static int codegen(information *const info)
 
 				for (size_t i = 0; i < parameters; i++)
 				{
-					const item_t param_displ = ident_get_displ(info->sx, (size_t)node_get_arg(&root, 0));
-					const item_t param_type = ident_get_type(info->sx, (size_t)node_get_arg(&root, 0));
+					const size_t type = (size_t)node_get_arg(&root, 0);
+					const item_t param_displ = ident_get_displ(info->sx, type);
+					const item_t param_type = ident_get_type(info->sx, type);
 					node_set_next(&root);
 
 					uni_printf(info->sx->io, " %%var.%" PRIitem " = alloca ", param_displ);

--- a/libs/compiler/llvmgen.c
+++ b/libs/compiler/llvmgen.c
@@ -29,7 +29,6 @@
 
 static const size_t HASH_TABLE_SIZE = 1024;
 static const size_t IS_STATIC = 0;
-static const size_t DIMENSION_LOW_BORDER = 1;
 static const size_t MAX_DIMENSIONS = SIZE_MAX - 2;		// Из-за OP_SLICE
 
 

--- a/libs/compiler/llvmgen.c
+++ b/libs/compiler/llvmgen.c
@@ -1808,7 +1808,6 @@ int encode_to_llvm(const workspace *const ws, syntax *const sx)
 	{
 		return -1;
 	}
-	// tables_and_tree("tree.txt", &(sx->identifiers), &(sx->types), &(sx->tree));
 
 	information info;
 	info.sx = sx;

--- a/libs/compiler/llvmgen.c
+++ b/libs/compiler/llvmgen.c
@@ -1781,7 +1781,7 @@ int encode_to_llvm(const workspace *const ws, syntax *const sx)
 	{
 		return -1;
 	}
-	tables_and_tree("tree.txt", &(sx->identifiers), &(sx->types), &(sx->tree));
+	// tables_and_tree("tree.txt", &(sx->identifiers), &(sx->types), &(sx->tree));
 
 	information info;
 	info.sx = sx;


### PR DESCRIPTION
После просмотра Ильёй кодогенератора llvm были реализованы несколько изменений в вызове и объявлении функций: переделано объявление параметров функции, вызов функции в представлении llvm теперь делается по имени, исправлен баг с функцией main (суть бага в том, что main не могла быть void). Также реализована работа с файлами, необходимая для [VOK](https://github.com/andrey-terekhov/RuC/blob/a09a830a8e46e0fc36f8d46189828470f8dbdf1b/tests/reutovr.c). Теперь можно завести файловую переменную, использовать fopen, fgetc и fclose.