### PR TITLE
Интерфейс синтаксического дерева

### DIFF
--- a/libs/compiler/AST.c
+++ b/libs/compiler/AST.c
@@ -112,19 +112,24 @@ expression_t expression_get_class(const node *const nd)
 {
 	switch (node_get_type(nd))
 	{
-		case OP_IDENTIFIER:	return EXPR_IDENTIFIER;
-		case OP_LITERAL:	return EXPR_LITERAL;
-
-		case OP_SLICE:		return EXPR_SUBSCRIPT;
-		case OP_CALL:		return EXPR_CALL;
-		case OP_SELECT:		return EXPR_MEMBER;
-
-		case OP_UNARY:		return EXPR_UNARY;
-		case OP_BINARY:		return EXPR_BINARY;
-		case OP_TERNARY:	return EXPR_TERNARY;
-
-		case OP_LIST:		return EXPR_LIST;
-
+		case OP_IDENTIFIER:
+			return EXPR_IDENTIFIER;
+		case OP_LITERAL:
+			return EXPR_LITERAL;
+		case OP_SLICE:
+			return EXPR_SUBSCRIPT;
+		case OP_CALL:
+			return EXPR_CALL;
+		case OP_SELECT:
+			return EXPR_MEMBER;
+		case OP_UNARY:
+			return EXPR_UNARY;
+		case OP_BINARY:
+			return EXPR_BINARY;
+		case OP_TERNARY:
+			return EXPR_TERNARY;
+		case OP_LIST:
+			return EXPR_LIST;
 		default:
 			system_error(node_unexpected);
 			return 0;
@@ -137,30 +142,40 @@ statement_t statement_get_class(const node *const nd)
 	{
 		case OP_DECL_VAR:
 		case OP_DECL_TYPE:
-		case OP_FUNC_DEF:	return STMT_DECL;
-
-		case OP_LABEL:		return STMT_LABEL;
-		case OP_CASE:		return STMT_CASE;
-		case OP_DEFAULT:	return STMT_DEFAULT;
-
-		case OP_BLOCK:		return STMT_COMPOUND;
-		case OP_NOP:		return STMT_NULL;
-
-		case OP_IF:			return STMT_IF;
-		case OP_SWITCH:		return STMT_SWITCH;
-
-		case OP_WHILE:		return STMT_WHILE;
-		case OP_DO:			return STMT_DO;
-		case OP_FOR:		return STMT_FOR;
-
-		case OP_GOTO:		return STMT_GOTO;
-		case OP_CONTINUE:	return STMT_CONTINUE;
-		case OP_BREAK:		return STMT_BREAK;
-		case OP_RETURN:		return STMT_RETURN;
-
-		case OP_PRINTF:		return STMT_PRINTF;
-
-		default:			return STMT_EXPR;
+		case OP_FUNC_DEF:
+			return STMT_DECL;
+		case OP_LABEL:
+			return STMT_LABEL;
+		case OP_CASE:
+			return STMT_CASE;
+		case OP_DEFAULT:
+			return STMT_DEFAULT;
+		case OP_BLOCK:
+			return STMT_COMPOUND;
+		case OP_NOP:
+			return STMT_NULL;
+		case OP_IF:
+			return STMT_IF;
+		case OP_SWITCH:
+			return STMT_SWITCH;
+		case OP_WHILE:
+			return STMT_WHILE;
+		case OP_DO:
+			return STMT_DO;
+		case OP_FOR:
+			return STMT_FOR;
+		case OP_GOTO:
+			return STMT_GOTO;
+		case OP_CONTINUE:
+			return STMT_CONTINUE;
+		case OP_BREAK:
+			return STMT_BREAK;
+		case OP_RETURN:
+			return STMT_RETURN;
+		case OP_PRINTF:
+			return STMT_PRINTF;
+		default:
+			return STMT_EXPR;
 	}
 }
 
@@ -168,10 +183,12 @@ declaration_t declaration_get_class(const node *const nd)
 {
 	switch (node_get_type(nd))
 	{
-		case OP_DECL_VAR:	return DECL_VAR;
-		case OP_DECL_TYPE:	return DECL_TYPE;
-		case OP_FUNC_DEF:	return DECL_FUNC;
-
+		case OP_DECL_VAR:
+			return DECL_VAR;
+		case OP_DECL_TYPE:
+			return DECL_TYPE;
+		case OP_FUNC_DEF:
+			return DECL_FUNC;
 		default:
 			system_error(node_unexpected);
 			return 0;

--- a/libs/compiler/AST.c
+++ b/libs/compiler/AST.c
@@ -1,0 +1,192 @@
+/*
+ *	Copyright 2021 Andrey Terekhov, Ilya Andreev
+ *
+ *	Licensed under the Apache License, Version 2.0 (the "License");
+ *	you may not use this file except in compliance with the License.
+ *	You may obtain a copy of the License at
+ *
+ *		http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *	Unless required by applicable law or agreed to in writing, software
+ *	distributed under the License is distributed on an "AS IS" BASIS,
+ *	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *	See the License for the specific language governing permissions and
+ *	limitations under the License.
+ */
+
+#include "AST.h"
+
+extern node node_broken(const node *const nd);
+
+extern item_t expression_get_type(const node *const nd);
+extern bool expression_is_lvalue(const node *const nd);
+extern location expression_get_location(const node *const nd);
+
+extern size_t identifier_expr_get_id(const node *const nd);
+extern int literal_expr_get_int(const node *const nd);
+extern double literal_expr_get_double(const node *const nd);
+extern size_t literal_expr_get_string(const node *const nd);
+
+extern node subscript_expr_get_base(const node *const nd);
+extern node subscript_expr_get_index(const node *const nd);
+
+extern node call_expr_get_callee(const node *const nd);
+extern node call_expr_get_argument(const node *const nd, const size_t index);
+
+extern node member_expr_get_base(const node *const nd);
+extern size_t member_expr_get_member_displ(const node *const nd);
+
+extern unary_t unary_expr_get_operator(const node *const nd);
+extern node unary_expr_get_operand(const node *const nd);
+
+extern binary_t binary_expr_get_operator(const node *const nd);
+extern node binary_expr_get_LHS(const node *const nd);
+extern node binary_expr_get_RHS(const node *const nd);
+
+extern node ternary_expr_get_condition(const node *const nd);
+extern node ternary_expr_get_LHS(const node *const nd);
+extern node ternary_expr_get_RHS(const node *const nd);
+
+extern size_t expression_list_get_size(const node *const nd);
+extern node expression_list_get_subexpr(const node *const nd, const size_t index);
+
+
+extern size_t labeled_stmt_get_label(const node *const nd);
+extern node labeled_stmt_get_substmt(const node *const nd);
+
+extern size_t compound_stmt_get_size(const node *const nd);
+extern node compound_stmt_get_substmt(const node *const nd, const size_t index);
+
+extern bool if_stmt_has_else(const node *const nd);
+extern node if_stmt_get_condition(const node *const nd);
+extern node if_stmt_get_then_substmt(const node *const nd);
+extern node if_stmt_get_else_substmt(const node *const nd);
+
+extern node while_stmt_get_condition(const node *const nd);
+extern node while_stmt_get_body(const node *const nd);
+
+extern node do_stmt_get_condition(const node *const nd);
+extern node do_stmt_get_body(const node *const nd);
+
+extern bool for_stmt_has_inition(const node *const nd);
+extern bool for_stmt_has_condition(const node *const nd);
+extern bool for_stmt_has_increment(const node *const nd);
+extern node for_stmt_get_inition(const node *const nd);
+extern node for_stmt_get_condition(const node *const nd);
+extern node for_stmt_get_increment(const node *const nd);
+extern node for_stmt_get_body(const node *const nd);
+
+extern size_t goto_stmt_get_label(const node *const nd);
+
+extern bool return_stmt_has_expression(const node *const nd);
+extern node return_stmt_get_expression(const node *const nd);
+
+extern size_t printf_stmt_get_argc(const node *const nd);
+extern node printf_stmt_get_format_str(const node *const nd);
+extern node printf_stmt_get_argument(const node *const nd, const size_t index);
+
+
+extern size_t translation_unit_get_size(const node *const nd);
+extern node translation_unit_get_declaration(const node *const nd, const size_t index);
+
+extern size_t variable_decl_get_id(const node *const nd);
+extern bool variable_decl_has_initializer(const node *const nd);
+extern node variable_decl_get_initializer(const node *const nd);
+extern size_t variable_decl_get_dim_amount(const node *const nd);
+extern node variable_decl_get_dim_expr(const node *const nd, const size_t index);
+
+extern size_t function_decl_get_id(const node *const nd);
+extern node function_decl_get_body(const node *const nd);
+
+
+/*
+ *	 __     __   __     ______   ______     ______     ______   ______     ______     ______
+ *	/\ \   /\ "-.\ \   /\__  _\ /\  ___\   /\  == \   /\  ___\ /\  __ \   /\  ___\   /\  ___\
+ *	\ \ \  \ \ \-.  \  \/_/\ \/ \ \  __\   \ \  __<   \ \  __\ \ \  __ \  \ \ \____  \ \  __\
+ *	 \ \_\  \ \_\\"\_\    \ \_\  \ \_____\  \ \_\ \_\  \ \_\    \ \_\ \_\  \ \_____\  \ \_____\
+ *	  \/_/   \/_/ \/_/     \/_/   \/_____/   \/_/ /_/   \/_/     \/_/\/_/   \/_____/   \/_____/
+ */
+
+
+#include <stdio.h>
+expression_t expression_get_class(const node *const nd)
+{
+	switch (node_get_type(nd))
+	{
+		case OP_IDENTIFIER:	return EXPR_IDENTIFIER;
+		case OP_LITERAL:	return EXPR_LITERAL;
+
+		case OP_SLICE:		return EXPR_SUBSCRIPT;
+		case OP_CALL:		return EXPR_CALL;
+		case OP_SELECT:		return EXPR_MEMBER;
+
+		case OP_UNARY:		return EXPR_UNARY;
+		case OP_BINARY:		return EXPR_BINARY;
+		case OP_TERNARY:	return EXPR_TERNARY;
+
+		case OP_LIST:		return EXPR_LIST;
+
+		default:
+			system_error(node_unexpected);
+			return 0;
+	}
+}
+
+statement_t statement_get_class(const node *const nd)
+{
+	switch (node_get_type(nd))
+	{
+		case OP_DECL_VAR:
+		case OP_DECL_TYPE:
+		case OP_FUNC_DEF:	return STMT_DECL;
+
+		case OP_LABEL:		return STMT_LABEL;
+		case OP_CASE:		return STMT_CASE;
+		case OP_DEFAULT:	return STMT_DEFAULT;
+
+		case OP_BLOCK:		return STMT_COMPOUND;
+		case OP_NOP:		return STMT_NULL;
+
+		case OP_IF:			return STMT_IF;
+		case OP_SWITCH:		return STMT_SWITCH;
+
+		case OP_WHILE:		return STMT_WHILE;
+		case OP_DO:			return STMT_DO;
+		case OP_FOR:		return STMT_FOR;
+
+		case OP_GOTO:		return STMT_GOTO;
+		case OP_CONTINUE:	return STMT_CONTINUE;
+		case OP_BREAK:		return STMT_BREAK;
+		case OP_RETURN:		return STMT_RETURN;
+
+		case OP_PRINTF:		return STMT_PRINTF;
+
+		default:			return STMT_EXPR;
+	}
+}
+
+declaration_t declaration_get_class(const node *const nd)
+{
+	switch (node_get_type(nd))
+	{
+		case OP_DECL_VAR:	return DECL_VAR;
+		case OP_DECL_TYPE:	return DECL_TYPE;
+		case OP_FUNC_DEF:	return DECL_FUNC;
+
+		default:
+			system_error(node_unexpected);
+			return 0;
+	}
+}
+
+
+size_t function_decl_get_param(const node *const nd, const size_t index)
+{
+	if (node_get_type(nd) != OP_FUNC_DEF)
+	{
+		return SIZE_MAX;
+	}
+
+	const node nd_parameter = node_get_child(nd, index);
+	return (size_t)node_get_arg(&nd_parameter, 0);
+}

--- a/libs/compiler/AST.c
+++ b/libs/compiler/AST.c
@@ -24,7 +24,7 @@ extern location expression_get_location(const node *const nd);
 
 extern size_t expression_identifier_get_id(const node *const nd);
 extern int expression_literal_get_integer(const node *const nd);
-extern double expression_literal_get_double(const node *const nd);
+extern double expression_literal_get_floating(const node *const nd);
 extern size_t expression_literal_get_string(const node *const nd);
 
 extern node expression_subscript_get_base(const node *const nd);

--- a/libs/compiler/AST.c
+++ b/libs/compiler/AST.c
@@ -22,81 +22,81 @@ extern item_t expression_get_type(const node *const nd);
 extern bool expression_is_lvalue(const node *const nd);
 extern location expression_get_location(const node *const nd);
 
-extern size_t identifier_expr_get_id(const node *const nd);
-extern int literal_expr_get_int(const node *const nd);
-extern double literal_expr_get_double(const node *const nd);
-extern size_t literal_expr_get_string(const node *const nd);
+extern size_t expression_identifier_get_id(const node *const nd);
+extern int expression_literal_get_integer(const node *const nd);
+extern double expression_literal_get_double(const node *const nd);
+extern size_t expression_literal_get_string(const node *const nd);
 
-extern node subscript_expr_get_base(const node *const nd);
-extern node subscript_expr_get_index(const node *const nd);
+extern node expression_subscript_get_base(const node *const nd);
+extern node expression_subscript_get_index(const node *const nd);
 
-extern node call_expr_get_callee(const node *const nd);
-extern node call_expr_get_argument(const node *const nd, const size_t index);
+extern node expression_call_get_callee(const node *const nd);
+extern node expression_call_get_argument(const node *const nd, const size_t index);
 
-extern node member_expr_get_base(const node *const nd);
-extern size_t member_expr_get_member_displ(const node *const nd);
+extern node expression_member_get_base(const node *const nd);
+extern size_t expression_member_get_member_displ(const node *const nd);
 
-extern unary_t unary_expr_get_operator(const node *const nd);
-extern node unary_expr_get_operand(const node *const nd);
+extern unary_t expression_unary_get_operator(const node *const nd);
+extern node expression_unary_get_operand(const node *const nd);
 
-extern binary_t binary_expr_get_operator(const node *const nd);
-extern node binary_expr_get_LHS(const node *const nd);
-extern node binary_expr_get_RHS(const node *const nd);
+extern binary_t expression_binary_get_operator(const node *const nd);
+extern node expression_binary_get_LHS(const node *const nd);
+extern node expression_binary_get_RHS(const node *const nd);
 
-extern node ternary_expr_get_condition(const node *const nd);
-extern node ternary_expr_get_LHS(const node *const nd);
-extern node ternary_expr_get_RHS(const node *const nd);
+extern node expression_ternary_get_condition(const node *const nd);
+extern node expression_ternary_get_LHS(const node *const nd);
+extern node expression_ternary_get_RHS(const node *const nd);
 
 extern size_t expression_list_get_size(const node *const nd);
 extern node expression_list_get_subexpr(const node *const nd, const size_t index);
 
 
-extern size_t labeled_stmt_get_label(const node *const nd);
-extern node labeled_stmt_get_substmt(const node *const nd);
+extern size_t statement_labeled_get_label(const node *const nd);
+extern node statement_labeled_get_substmt(const node *const nd);
 
-extern size_t compound_stmt_get_size(const node *const nd);
-extern node compound_stmt_get_substmt(const node *const nd, const size_t index);
+extern size_t statement_compound_get_size(const node *const nd);
+extern node statement_compound_get_substmt(const node *const nd, const size_t index);
 
-extern bool if_stmt_has_else(const node *const nd);
-extern node if_stmt_get_condition(const node *const nd);
-extern node if_stmt_get_then_substmt(const node *const nd);
-extern node if_stmt_get_else_substmt(const node *const nd);
+extern bool statement_if_has_else_substmt(const node *const nd);
+extern node statement_if_get_condition(const node *const nd);
+extern node statement_if_get_then_substmt(const node *const nd);
+extern node statement_if_get_else_substmt(const node *const nd);
 
-extern node while_stmt_get_condition(const node *const nd);
-extern node while_stmt_get_body(const node *const nd);
+extern node statement_while_get_condition(const node *const nd);
+extern node statement_while_get_body(const node *const nd);
 
-extern node do_stmt_get_condition(const node *const nd);
-extern node do_stmt_get_body(const node *const nd);
+extern node statement_do_get_condition(const node *const nd);
+extern node statement_do_get_body(const node *const nd);
 
-extern bool for_stmt_has_inition(const node *const nd);
-extern bool for_stmt_has_condition(const node *const nd);
-extern bool for_stmt_has_increment(const node *const nd);
-extern node for_stmt_get_inition(const node *const nd);
-extern node for_stmt_get_condition(const node *const nd);
-extern node for_stmt_get_increment(const node *const nd);
-extern node for_stmt_get_body(const node *const nd);
+extern bool statement_for_has_inition(const node *const nd);
+extern bool statement_for_has_condition(const node *const nd);
+extern bool statement_for_has_increment(const node *const nd);
+extern node statement_for_get_inition(const node *const nd);
+extern node statement_for_get_condition(const node *const nd);
+extern node statement_for_get_increment(const node *const nd);
+extern node statement_for_get_body(const node *const nd);
 
-extern size_t goto_stmt_get_label(const node *const nd);
+extern size_t statement_goto_get_label(const node *const nd);
 
-extern bool return_stmt_has_expression(const node *const nd);
-extern node return_stmt_get_expression(const node *const nd);
+extern bool statement_return_has_expression(const node *const nd);
+extern node statement_return_get_expression(const node *const nd);
 
-extern size_t printf_stmt_get_argc(const node *const nd);
-extern node printf_stmt_get_format_str(const node *const nd);
-extern node printf_stmt_get_argument(const node *const nd, const size_t index);
+extern size_t statement_printf_get_argc(const node *const nd);
+extern node statement_printf_get_format_str(const node *const nd);
+extern node statement_printf_get_argument(const node *const nd, const size_t index);
 
 
 extern size_t translation_unit_get_size(const node *const nd);
 extern node translation_unit_get_declaration(const node *const nd, const size_t index);
 
-extern size_t variable_decl_get_id(const node *const nd);
-extern bool variable_decl_has_initializer(const node *const nd);
-extern node variable_decl_get_initializer(const node *const nd);
-extern size_t variable_decl_get_dim_amount(const node *const nd);
-extern node variable_decl_get_dim_expr(const node *const nd, const size_t index);
+extern size_t declaration_variable_get_id(const node *const nd);
+extern bool declaration_variable_has_initializer(const node *const nd);
+extern node declaration_variable_get_initializer(const node *const nd);
+extern size_t declaration_variable_get_dim_amount(const node *const nd);
+extern node declaration_variable_get_dim_expr(const node *const nd, const size_t index);
 
-extern size_t function_decl_get_id(const node *const nd);
-extern node function_decl_get_body(const node *const nd);
+extern size_t declaration_function_get_id(const node *const nd);
+extern node declaration_function_get_body(const node *const nd);
 
 
 /*
@@ -108,7 +108,6 @@ extern node function_decl_get_body(const node *const nd);
  */
 
 
-#include <stdio.h>
 expression_t expression_get_class(const node *const nd)
 {
 	switch (node_get_type(nd))
@@ -180,7 +179,7 @@ declaration_t declaration_get_class(const node *const nd)
 }
 
 
-size_t function_decl_get_param(const node *const nd, const size_t index)
+size_t declaration_function_get_param(const node *const nd, const size_t index)
 {
 	if (node_get_type(nd) != OP_FUNC_DEF)
 	{

--- a/libs/compiler/AST.c
+++ b/libs/compiler/AST.c
@@ -16,7 +16,7 @@
 
 #include "AST.h"
 
-extern node node_broken(const node *const nd);
+extern node node_broken();
 
 extern item_t expression_get_type(const node *const nd);
 extern bool expression_is_lvalue(const node *const nd);

--- a/libs/compiler/AST.h
+++ b/libs/compiler/AST.h
@@ -32,7 +32,7 @@ typedef enum CATEGORY
 	RVALUE,				/**< An expression detached from any specific storage */
 } category_t;
 
-/** Expression kinds */
+/** Expression class */
 typedef enum EXPRESSION
 {
 	EXPR_IDENTIFIER,	/**< Identifier expression */
@@ -46,7 +46,7 @@ typedef enum EXPRESSION
 	EXPR_LIST,			/**< Expression list */
 } expression_t;
 
-/** Statement kinds */
+/** Statement class */
 typedef enum STATEMENT
 {
 	STMT_DECL,			/**< Declaration statement */
@@ -68,11 +68,11 @@ typedef enum STATEMENT
 	STMT_PRINTF,		/**< Printf statement */
 } statement_t;
 
-/** Declaration kinds */
+/** Declaration class */
 typedef enum DECLARATION
 {
 	DECL_VAR,			/**< Variable declaration */
-	DECL_FUNC,			/**< Function definition */
+	DECL_FUNC,			/**< Function declaration */
 	DECL_TYPE,			/**< Type declaration */
 } declaration_t;
 
@@ -829,7 +829,7 @@ inline node declaration_function_get_body(const node *const nd)
  */
 inline size_t translation_unit_get_size(const node *const nd)
 {
-	return node_is_correct(nd) && node_get_type(nd) == ITEM_MAX ? node_get_amount(nd) : SIZE_MAX;
+	return node_get_type(nd) == ITEM_MAX && node_is_correct(nd) ? node_get_amount(nd) : SIZE_MAX;
 }
 
 /**
@@ -842,7 +842,7 @@ inline size_t translation_unit_get_size(const node *const nd)
  */
 inline node translation_unit_get_declaration(const node *const nd, const size_t index)
 {
-	return node_is_correct(nd) && node_get_type(nd) == ITEM_MAX ? node_get_child(nd, index) : node_broken();
+	return node_get_type(nd) == ITEM_MAX && node_is_correct(nd) ? node_get_child(nd, index) : node_broken();
 }
 
 #ifdef __cplusplus

--- a/libs/compiler/AST.h
+++ b/libs/compiler/AST.h
@@ -161,13 +161,13 @@ inline int expression_literal_get_integer(const node *const nd)
 }
 
 /**
- *	Get double value of literal expression
+ *	Get floating value of literal expression
  *
  *	@param	nd		Literal expression
  *
- *	@return	Double value
+ *	@return	Floating value
  */
-inline double expression_literal_get_double(const node *const nd)
+inline double expression_literal_get_floating(const node *const nd)
 {
 	return node_get_type(nd) == OP_LITERAL ? node_get_arg_double(nd, 2) : DBL_MAX;
 }

--- a/libs/compiler/AST.h
+++ b/libs/compiler/AST.h
@@ -40,11 +40,42 @@ typedef enum EXPRESSION
 } expression_t;
 
 /** Value category */
-typedef enum VALUE
+typedef enum CATEGORY
 {
 	LVALUE,				/**< An expression that designates an object */
 	RVALUE,				/**< An expression detached from any specific storage */
 } category_t;
+
+/** Statement kinds */
+typedef enum STATEMENT
+{
+	STMT_DECL,			/**< Declaration statement */
+	STMT_LABEL,			/**< Labeled statement */
+	STMT_CASE,			/**< Case statement */
+	STMT_DEFAULT,		/**< Default statement */
+	STMT_COMPOUND,		/**< Compound statement */
+	STMT_EXPR,			/**< Expression statement */
+	STMT_NULL,			/**< Null statement */
+	STMT_IF,			/**< If statement */
+	STMT_SWITCH,		/**< Switch statement */
+	STMT_WHILE,			/**< While statement */
+	STMT_DO,			/**< Do statement */
+	STMT_FOR,			/**< For statement */
+	STMT_GOTO,			/**< Goto statement */
+	STMT_CONTINUE,		/**< Continue statement */
+	STMT_BREAK,			/**< Break statement */
+	STMT_RETURN,		/**< Return statement */
+	STMT_PRINTF,		/**< Printf statement */
+} statement_t;
+
+/** Declaration kinds */
+typedef enum DECLARATION
+{
+	DECL_VAR,			/**< Variable declaration */
+	DECL_FUNC,			/**< Function definition */
+	DECL_TYPE,			/**< Type declaration */
+} declaration_t;
+
 
 /**
  *	Build a broken node
@@ -55,6 +86,7 @@ inline node node_broken()
 {
 	return node_load(NULL, SIZE_MAX);
 }
+
 
 /**
  *	Get expression class
@@ -102,6 +134,7 @@ inline location expression_get_location(const node *const nd)
 	return (location){ (size_t)node_get_arg(nd, argc - 2), (size_t)node_get_arg(nd, argc - 1) };
 }
 
+
 /**
  *	Get id of identifier expression
  *
@@ -109,10 +142,11 @@ inline location expression_get_location(const node *const nd)
  *
  *	@return	Id
  */
-inline size_t identifier_expr_get_id(const node *const nd)
+inline size_t expression_identifier_get_id(const node *const nd)
 {
 	return node_get_type(nd) == OP_IDENTIFIER ? (size_t)node_get_arg(nd, 2) : SIZE_MAX;
 }
+
 
 /**
  *	Get integer value of literal expression
@@ -121,7 +155,7 @@ inline size_t identifier_expr_get_id(const node *const nd)
  *
  *	@return	Integer value
  */
-inline int literal_expr_get_int(const node *const nd)
+inline int expression_literal_get_integer(const node *const nd)
 {
 	return node_get_type(nd) == OP_LITERAL ? (int)node_get_arg(nd, 2) : INT_MAX;
 }
@@ -133,7 +167,7 @@ inline int literal_expr_get_int(const node *const nd)
  *
  *	@return	Double value
  */
-inline double literal_expr_get_double(const node *const nd)
+inline double expression_literal_get_double(const node *const nd)
 {
 	return node_get_type(nd) == OP_LITERAL ? node_get_arg_double(nd, 2) : DBL_MAX;
 }
@@ -145,7 +179,7 @@ inline double literal_expr_get_double(const node *const nd)
  *
  *	@return	String index
  */
-inline size_t literal_expr_get_string(const node *const nd)
+inline size_t expression_literal_get_string(const node *const nd)
 {
 	return node_get_type(nd) == OP_LITERAL ? (size_t)node_get_arg(nd, 2) : SIZE_MAX;
 }
@@ -158,7 +192,7 @@ inline size_t literal_expr_get_string(const node *const nd)
  *
  *	@return	Base expression
  */
-inline node subscript_expr_get_base(const node *const nd)
+inline node expression_subscript_get_base(const node *const nd)
 {
 	return node_get_type(nd) == OP_SLICE ? node_get_child(nd, 0) : node_broken();
 }
@@ -170,7 +204,7 @@ inline node subscript_expr_get_base(const node *const nd)
  *
  *	@return	Index expression
  */
-inline node subscript_expr_get_index(const node *const nd)
+inline node expression_subscript_get_index(const node *const nd)
 {
 	return node_get_type(nd) == OP_SLICE ? node_get_child(nd, 1) : node_broken();
 }
@@ -183,7 +217,7 @@ inline node subscript_expr_get_index(const node *const nd)
  *
  *	@return	Called expression
  */
-inline node call_expr_get_callee(const node *const nd)
+inline node expression_call_get_callee(const node *const nd)
 {
 	return node_get_type(nd) == OP_CALL ? node_get_child(nd, 0) : node_broken();
 }
@@ -196,7 +230,7 @@ inline node call_expr_get_callee(const node *const nd)
  *
  *	@return	Argument
  */
-inline node call_expr_get_argument(const node *const nd, const size_t index)
+inline node expression_call_get_argument(const node *const nd, const size_t index)
 {
 	return node_get_type(nd) == OP_CALL ? node_get_child(nd, 1 + index) : node_broken();
 }
@@ -209,7 +243,7 @@ inline node call_expr_get_argument(const node *const nd, const size_t index)
  *
  *	@return	Base expression
  */
-inline node member_expr_get_base(const node *const nd)
+inline node expression_member_get_base(const node *const nd)
 {
 	return node_get_type(nd) == OP_SELECT ? node_get_child(nd, 0) : node_broken();
 }
@@ -221,7 +255,7 @@ inline node member_expr_get_base(const node *const nd)
  *
  *	@return	Member displacement
  */
-inline size_t member_expr_get_member_displ(const node *const nd)
+inline size_t expression_member_get_member_displ(const node *const nd)
 {
 	return node_get_type(nd) == OP_SELECT ? (size_t)node_get_arg(nd, 2) : SIZE_MAX;
 }
@@ -234,7 +268,7 @@ inline size_t member_expr_get_member_displ(const node *const nd)
  *
  *	@return	Operator
  */
-inline unary_t unary_expr_get_operator(const node *const nd)
+inline unary_t expression_unary_get_operator(const node *const nd)
 {
 	return node_get_type(nd) == OP_UNARY ? (unary_t)node_get_arg(nd, 2) : INT_MAX;
 }
@@ -246,7 +280,7 @@ inline unary_t unary_expr_get_operator(const node *const nd)
  *
  *	@return	Operand
  */
-inline node unary_expr_get_operand(const node *const nd)
+inline node expression_unary_get_operand(const node *const nd)
 {
 	return node_get_type(nd) == OP_UNARY ? node_get_child(nd, 0) : node_broken();
 }
@@ -259,7 +293,7 @@ inline node unary_expr_get_operand(const node *const nd)
  *
  *	@return	Operator
  */
-inline binary_t binary_expr_get_operator(const node *const nd)
+inline binary_t expression_binary_get_operator(const node *const nd)
 {
 	return node_get_type(nd) == OP_BINARY ? (binary_t)node_get_arg(nd, 2) : INT_MAX;
 }
@@ -271,7 +305,7 @@ inline binary_t binary_expr_get_operator(const node *const nd)
  *
  *	@return	LHS of binary expression
  */
-inline node binary_expr_get_LHS(const node *const nd)
+inline node expression_binary_get_LHS(const node *const nd)
 {
 	return node_get_type(nd) == OP_BINARY ? node_get_child(nd, 0) : node_broken();
 }
@@ -283,7 +317,7 @@ inline node binary_expr_get_LHS(const node *const nd)
  *
  *	@return	RHS of binary expression
  */
-inline node binary_expr_get_RHS(const node *const nd)
+inline node expression_binary_get_RHS(const node *const nd)
 {
 	return node_get_type(nd) == OP_BINARY ? node_get_child(nd, 1) : node_broken();
 }
@@ -296,7 +330,7 @@ inline node binary_expr_get_RHS(const node *const nd)
  *
  *	@return	Condition
  */
-inline node ternary_expr_get_condition(const node *const nd)
+inline node expression_ternary_get_condition(const node *const nd)
 {
 	return node_get_type(nd) == OP_TERNARY ? node_get_child(nd, 0) : node_broken();
 }
@@ -308,7 +342,7 @@ inline node ternary_expr_get_condition(const node *const nd)
  *
  *	@return	LHS of ternary expression
  */
-inline node ternary_expr_get_LHS(const node *const nd)
+inline node expression_ternary_get_LHS(const node *const nd)
 {
 	return node_get_type(nd) == OP_TERNARY ? node_get_child(nd, 1) : node_broken();
 }
@@ -320,7 +354,7 @@ inline node ternary_expr_get_LHS(const node *const nd)
  *
  *	@return	RHS of ternary expression
  */
-inline node ternary_expr_get_RHS(const node *const nd)
+inline node expression_ternary_get_RHS(const node *const nd)
 {
 	return node_get_type(nd) == OP_TERNARY ? node_get_child(nd, 2) : node_broken();
 }
@@ -339,10 +373,10 @@ inline size_t expression_list_get_size(const node *const nd)
 }
 
 /**
- *	Get expression of expression list by index
+ *	Get subexpression of expression list by index
  *
  *	@param	nd		Expression list
- *	@param	index	Expression index
+ *	@param	index	Subexpression index
  *
  *	@return	Expression
  */
@@ -350,29 +384,6 @@ inline node expression_list_get_subexpr(const node *const nd, const size_t index
 {
 	return node_get_type(nd) == OP_LIST ? node_get_child(nd, index) : node_broken();
 }
-
-
-/** Statement kinds */
-typedef enum STATEMENT
-{
-	STMT_DECL,			/**< Declaration statement */
-	STMT_LABEL,			/**< Labeled statement */
-	STMT_CASE,			/**< Case statement */
-	STMT_DEFAULT,		/**< Default statement */
-	STMT_COMPOUND,		/**< Compound statement */
-	STMT_EXPR,			/**< Expression statement */
-	STMT_NULL,			/**< Null statement */
-	STMT_IF,			/**< If statement */
-	STMT_SWITCH,		/**< Switch statement */
-	STMT_WHILE,			/**< While statement */
-	STMT_DO,			/**< Do statement */
-	STMT_FOR,			/**< For statement */
-	STMT_GOTO,			/**< Goto statement */
-	STMT_CONTINUE,		/**< Continue statement */
-	STMT_BREAK,			/**< Break statement */
-	STMT_RETURN,		/**< Return statement */
-	STMT_PRINTF,		/**< Printf statement */
-} statement_t;
 
 
 /**
@@ -392,7 +403,7 @@ statement_t statement_get_class(const node *const nd);
  *
  *	@return	Label id
  */
-inline size_t labeled_stmt_get_label(const node *const nd)
+inline size_t statement_labeled_get_label(const node *const nd)
 {
 	return node_get_type(nd) == OP_LABEL ? (size_t)node_get_arg(nd, 0) : SIZE_MAX;
 }
@@ -404,7 +415,7 @@ inline size_t labeled_stmt_get_label(const node *const nd)
  *
  *	@return	Substatement
  */
-inline node labeled_stmt_get_substmt(const node *const nd)
+inline node statement_labeled_get_substmt(const node *const nd)
 {
 	return node_get_type(nd) == OP_LABEL ? node_get_child(nd, 0) : node_broken();
 }
@@ -417,7 +428,7 @@ inline node labeled_stmt_get_substmt(const node *const nd)
  *
  *	@return	Size
  */
-inline size_t compound_stmt_get_size(const node *const nd)
+inline size_t statement_compound_get_size(const node *const nd)
 {
 	return node_get_type(nd) == OP_BLOCK ? node_get_amount(nd) : SIZE_MAX;
 }
@@ -430,7 +441,7 @@ inline size_t compound_stmt_get_size(const node *const nd)
  *
  *	@return	Substatement
  */
-inline node compound_stmt_get_substmt(const node *const nd, const size_t index)
+inline node statement_compound_get_substmt(const node *const nd, const size_t index)
 {
 	return node_get_type(nd) == OP_BLOCK ? node_get_child(nd, index) : node_broken();
 }
@@ -443,7 +454,7 @@ inline node compound_stmt_get_substmt(const node *const nd, const size_t index)
  *
  *	@return	@c 1 on true, @c 0 on false
  */
-inline bool if_stmt_has_else(const node *const nd)
+inline bool statement_if_has_else_substmt(const node *const nd)
 {
 	return node_get_type(nd) == OP_IF ? node_get_arg(nd, 0) != 0 : false;
 }
@@ -455,7 +466,7 @@ inline bool if_stmt_has_else(const node *const nd)
  *
  *	@return	Condition
  */
-inline node if_stmt_get_condition(const node *const nd)
+inline node statement_if_get_condition(const node *const nd)
 {
 	return node_get_type(nd) == OP_IF ? node_get_child(nd, 0) : node_broken();
 }
@@ -467,7 +478,7 @@ inline node if_stmt_get_condition(const node *const nd)
  *
  *	@return	Then-substatement
  */
-inline node if_stmt_get_then_substmt(const node *const nd)
+inline node statement_if_get_then_substmt(const node *const nd)
 {
 	return node_get_type(nd) == OP_IF ? node_get_child(nd, 1) : node_broken();
 }
@@ -479,9 +490,9 @@ inline node if_stmt_get_then_substmt(const node *const nd)
  *
  *	@return	Else-substatement
  */
-inline node if_stmt_get_else_substmt(const node *const nd)
+inline node statement_if_get_else_substmt(const node *const nd)
 {
-	return if_stmt_has_else(nd) ? node_get_child(nd, 2) : node_broken();
+	return statement_if_has_else_substmt(nd) ? node_get_child(nd, 2) : node_broken();
 }
 
 
@@ -492,7 +503,7 @@ inline node if_stmt_get_else_substmt(const node *const nd)
  *
  *	@return	Condition
  */
-inline node while_stmt_get_condition(const node *const nd)
+inline node statement_while_get_condition(const node *const nd)
 {
 	return node_get_type(nd) == OP_WHILE ? node_get_child(nd, 0) : node_broken();
 }
@@ -504,7 +515,7 @@ inline node while_stmt_get_condition(const node *const nd)
  *
  *	@return	Substatement
  */
-inline node while_stmt_get_body(const node *const nd)
+inline node statement_while_get_body(const node *const nd)
 {
 	return node_get_type(nd) == OP_WHILE ? node_get_child(nd, 1) : node_broken();
 }
@@ -517,7 +528,7 @@ inline node while_stmt_get_body(const node *const nd)
  *
  *	@return	Condition
  */
-inline node do_stmt_get_condition(const node *const nd)
+inline node statement_do_get_condition(const node *const nd)
 {
 	return node_get_type(nd) == OP_DO ? node_get_child(nd, 1) : node_broken();
 }
@@ -529,7 +540,7 @@ inline node do_stmt_get_condition(const node *const nd)
  *
  *	@return	Substatement
  */
-inline node do_stmt_get_body(const node *const nd)
+inline node statement_do_get_body(const node *const nd)
 {
 	return node_get_type(nd) == OP_DO ? node_get_child(nd, 0) : node_broken();
 }
@@ -542,7 +553,7 @@ inline node do_stmt_get_body(const node *const nd)
  *
  *	@return	@c 1 on true, @c 0 on false
  */
-inline bool for_stmt_has_inition(const node *const nd)
+inline bool statement_for_has_inition(const node *const nd)
 {
 	return node_get_type(nd) == OP_FOR ? node_get_arg(nd, 0) != 0 : false;
 }
@@ -554,7 +565,7 @@ inline bool for_stmt_has_inition(const node *const nd)
  *
  *	@return	@c 1 on true, @c 0 on false
  */
-inline bool for_stmt_has_condition(const node *const nd)
+inline bool statement_for_has_condition(const node *const nd)
 {
 	return node_get_type(nd) == OP_FOR ? node_get_arg(nd, 1) != 0 : false;
 }
@@ -566,7 +577,7 @@ inline bool for_stmt_has_condition(const node *const nd)
  *
  *	@return	@c 1 on true, @c 0 on false
  */
-inline bool for_stmt_has_increment(const node *const nd)
+inline bool statement_for_has_increment(const node *const nd)
 {
 	return node_get_type(nd) == OP_FOR ? node_get_arg(nd, 2) != 0 : false;
 }
@@ -578,9 +589,9 @@ inline bool for_stmt_has_increment(const node *const nd)
  *
  *	@return	Inition
  */
-inline node for_stmt_get_inition(const node *const nd)
+inline node statement_for_get_inition(const node *const nd)
 {
-	return for_stmt_has_inition(nd) ? node_get_child(nd, 0) : node_broken();
+	return statement_for_has_inition(nd) ? node_get_child(nd, 0) : node_broken();
 }
 
 /**
@@ -590,10 +601,10 @@ inline node for_stmt_get_inition(const node *const nd)
  *
  *	@return	condition
  */
-inline node for_stmt_get_condition(const node *const nd)
+inline node statement_for_get_condition(const node *const nd)
 {
-	return for_stmt_has_condition(nd)
-		? node_get_child(nd, for_stmt_has_inition(nd) ? 1 : 0)
+	return statement_for_has_condition(nd)
+		? node_get_child(nd, statement_for_has_inition(nd) ? 1 : 0)
 		: node_broken();
 }
 
@@ -604,9 +615,9 @@ inline node for_stmt_get_condition(const node *const nd)
  *
  *	@return	Increment
  */
-inline node for_stmt_get_increment(const node *const nd)
+inline node statement_for_get_increment(const node *const nd)
 {
-	return for_stmt_has_increment(nd)
+	return statement_for_has_increment(nd)
 		? node_get_child(nd, node_get_amount(nd) - 2)
 		: node_broken();
 }
@@ -618,7 +629,7 @@ inline node for_stmt_get_increment(const node *const nd)
  *
  *	@return	Substatement
  */
-inline node for_stmt_get_body(const node *const nd)
+inline node statement_for_get_body(const node *const nd)
 {
 	return node_get_type(nd) == OP_FOR
 		? node_get_child(nd, node_get_amount(nd) - 1)
@@ -633,7 +644,7 @@ inline node for_stmt_get_body(const node *const nd)
  *
  *	@return	Label id
  */
-inline size_t goto_stmt_get_label(const node *const nd)
+inline size_t statement_goto_get_label(const node *const nd)
 {
 	return node_get_type(nd) == OP_GOTO ? (size_t)node_get_arg(nd, 0) : SIZE_MAX;
 }
@@ -646,7 +657,7 @@ inline size_t goto_stmt_get_label(const node *const nd)
  *
  *	@return	@c 1 on true, @c 0 on false
  */
-inline bool return_stmt_has_expression(const node *const nd)
+inline bool statement_return_has_expression(const node *const nd)
 {
 	return node_get_type(nd) == OP_RETURN ? node_get_amount(nd) != 0 : false;
 }
@@ -658,9 +669,9 @@ inline bool return_stmt_has_expression(const node *const nd)
  *
  *	@return	Expression
  */
-inline node return_stmt_get_expression(const node *const nd)
+inline node statement_return_get_expression(const node *const nd)
 {
-	return return_stmt_has_expression(nd) ? node_get_child(nd, 0) : node_broken();
+	return statement_return_has_expression(nd) ? node_get_child(nd, 0) : node_broken();
 }
 
 /**
@@ -670,7 +681,7 @@ inline node return_stmt_get_expression(const node *const nd)
  *
  *	@return	Argument count
  */
-inline size_t printf_stmt_get_argc(const node *const nd)
+inline size_t statement_printf_get_argc(const node *const nd)
 {
 	return node_get_type(nd) == OP_PRINTF ? node_get_amount(nd) - 1 : 0;
 }
@@ -682,7 +693,7 @@ inline size_t printf_stmt_get_argc(const node *const nd)
  *
  *	@return	Format string
  */
-inline node printf_stmt_get_format_str(const node *const nd)
+inline node statement_printf_get_format_str(const node *const nd)
 {
 	return node_get_type(nd) == OP_PRINTF ? node_get_child(nd, 0) : node_broken();
 }
@@ -694,18 +705,10 @@ inline node printf_stmt_get_format_str(const node *const nd)
  *
  *	@return	Argument
  */
-inline node printf_stmt_get_argument(const node *const nd, const size_t index)
+inline node statement_printf_get_argument(const node *const nd, const size_t index)
 {
-	return printf_stmt_get_argc(nd) > index ? node_get_child(nd, 1 + index) : node_broken();
+	return statement_printf_get_argc(nd) > index ? node_get_child(nd, 1 + index) : node_broken();
 }
-
-
-typedef enum DECLARATION
-{
-	DECL_VAR,			/**< Variable declaration */
-	DECL_FUNC,			/**< Function definition */
-	DECL_TYPE,			/**< Type declaration */
-} declaration_t;
 
 
 /**
@@ -716,6 +719,105 @@ typedef enum DECLARATION
  *	@return	Declaration class
  */
 declaration_t declaration_get_class(const node *const nd);
+
+
+/**
+ *	Get variable id in variable declaration
+ *
+ *	@param	nd		Variable declaration
+ *
+ *	@return	Id
+ */
+inline size_t declaration_variable_get_id(const node *const nd)
+{
+	return node_get_type(nd) == OP_DECL_VAR ? (size_t)node_get_arg(nd, 0) : SIZE_MAX;
+}
+
+/**
+ *	Check if variable declaration has initializer
+ *
+ *	@param	nd		Variable declaration
+ *
+ *	@return	@c 1 on true, @c 0 on false
+ */
+inline bool declaration_variable_has_initializer(const node *const nd)
+{
+	return node_get_type(nd) == OP_DECL_VAR ? node_get_arg(nd, 2) != 0 : false;
+}
+
+/**
+ *	Get initializer of variable declaration
+ *
+ *	@param	nd		Variable declaration
+ *
+ *	@return	Initializer
+ */
+inline node declaration_variable_get_initializer(const node *const nd)
+{
+	return declaration_variable_has_initializer(nd) ? node_get_child(nd, node_get_amount(nd) - 1) : node_broken();
+}
+
+/**
+ *	Get amount of dimenstions of variable declaration
+ *
+ *	@param	nd		Variable declaration
+ *
+ *	@return	Amount of dimenstions
+ */
+inline size_t declaration_variable_get_dim_amount(const node *const nd)
+{
+	return node_get_type(nd) == OP_DECL_VAR
+		? node_get_amount(nd) - (declaration_variable_has_initializer(nd) ? 1 : 0)
+		: 0;
+}
+
+/**
+ *	Get size-expression of dimenstions of variable declaration by index
+ *
+ *	@param	nd		Variable declaration
+ *	@param	index	Dimansion index
+ *
+ *	@return	Size-expression
+ */
+inline node declaration_variable_get_dim_expr(const node *const nd, const size_t index)
+{
+	return declaration_variable_get_dim_amount(nd) > index ? node_get_child(nd, index) : node_broken();
+}
+
+
+/**
+ *	Get id of function in function declaration
+ *
+ *	@param	nd		Function declaration
+ *
+ *	@return Function id
+ */
+inline size_t declaration_function_get_id(const node *const nd)
+{
+	return node_get_type(nd) == OP_FUNC_DEF ? (size_t)node_get_arg(nd, 0) : SIZE_MAX;
+}
+
+/**
+ *	Get parameter id in function declaration by index
+ *
+ *	@param	nd		Function declaration
+ *	@param	index	Parameter index
+ *
+ *	@return Parameter id
+ */
+size_t declaration_function_get_param(const node *const nd, const size_t index);
+
+/**
+ *	Get body of function declaration
+ *
+ *	@param	nd		Function declaration
+ *
+ *	@return Function body
+ */
+inline node declaration_function_get_body(const node *const nd)
+{
+	return node_get_type(nd) == OP_FUNC_DEF ? node_get_child(nd, node_get_amount(nd) - 1) : node_broken();
+}
 
 
 /**
@@ -741,105 +843,6 @@ inline size_t translation_unit_get_size(const node *const nd)
 inline node translation_unit_get_declaration(const node *const nd, const size_t index)
 {
 	return node_is_correct(nd) && node_get_type(nd) == ITEM_MAX ? node_get_child(nd, index) : node_broken();
-}
-
-
-/**
- *	Get variable id in variable declaration
- *
- *	@param	nd		Variable declaration
- *
- *	@return	Id
- */
-inline size_t variable_decl_get_id(const node *const nd)
-{
-	return node_get_type(nd) == OP_DECL_VAR ? (size_t)node_get_arg(nd, 0) : SIZE_MAX;
-}
-
-/**
- *	Check if variable declaration has initializer
- *
- *	@param	nd		Variable declaration
- *
- *	@return	@c 1 on true, @c 0 on false
- */
-inline bool variable_decl_has_initializer(const node *const nd)
-{
-	return node_get_type(nd) == OP_DECL_VAR ? node_get_arg(nd, 2) != 0 : false;
-}
-
-/**
- *	Get initializer of variable declaration
- *
- *	@param	nd		Variable declaration
- *
- *	@return	Initializer
- */
-inline node variable_decl_get_initializer(const node *const nd)
-{
-	return variable_decl_has_initializer(nd) ? node_get_child(nd, node_get_amount(nd) - 1) : node_broken();
-}
-
-/**
- *	Get amount of dimenstions of variable declaration
- *
- *	@param	nd		Variable declaration
- *
- *	@return	Amount of dimenstions
- */
-inline size_t variable_decl_get_dim_amount(const node *const nd)
-{
-	return node_get_type(nd) == OP_DECL_VAR
-		? node_get_amount(nd) - (variable_decl_has_initializer(nd) ? 1 : 0)
-		: 0;
-}
-
-/**
- *	Get size-expression of dimenstions of variable declaration by index
- *
- *	@param	nd		Variable declaration
- *	@param	index	Dimansion index
- *
- *	@return	Size-expression
- */
-inline node variable_decl_get_dim_expr(const node *const nd, const size_t index)
-{
-	return variable_decl_get_dim_amount(nd) > index ? node_get_child(nd, index) : node_broken();
-}
-
-
-/**
- *	Get id of function in function declaration
- *
- *	@param	nd		Function declaration
- *
- *	@return Function id
- */
-inline size_t function_decl_get_id(const node *const nd)
-{
-	return node_get_type(nd) == OP_FUNC_DEF ? (size_t)node_get_arg(nd, 0) : SIZE_MAX;
-}
-
-/**
- *	Get parameter id in function declaration by index
- *
- *	@param	nd		Function declaration
- *	@param	index	Parameter index
- *
- *	@return Parameter id
- */
-size_t function_decl_get_param(const node *const nd, const size_t index);
-
-/**
- *	Get body of function declaration
- *
- *	@param	nd		Function declaration
- *
- *	@return Function body
- */
-inline node function_decl_get_body(const node *const nd)
-{
-	return node_get_type(nd) == OP_FUNC_DEF ? node_get_child(nd, node_get_amount(nd) - 1) : node_broken();
 }
 
 #ifdef __cplusplus

--- a/libs/compiler/AST.h
+++ b/libs/compiler/AST.h
@@ -1,0 +1,847 @@
+/*
+ *	Copyright 2021 Andrey Terekhov, Ilya Andreev
+ *
+ *	Licensed under the Apache License, Version 2.0 (the "License");
+ *	you may not use this file except in compliance with the License.
+ *	You may obtain a copy of the License at
+ *
+ *		http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *	Unless required by applicable law or agreed to in writing, software
+ *	distributed under the License is distributed on an "AS IS" BASIS,
+ *	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *	See the License for the specific language governing permissions and
+ *	limitations under the License.
+ */
+
+#pragma once
+
+#include "operations.h"
+#include "tree.h"
+#include "syntax.h"
+
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/** Expression kinds */
+typedef enum EXPRESSION
+{
+	EXPR_IDENTIFIER,	/**< Identifier expression */
+	EXPR_LITERAL,		/**< Literal expression */
+	EXPR_SUBSCRIPT,		/**< Subscript expression */
+	EXPR_CALL,			/**< Call expression */
+	EXPR_MEMBER,		/**< Member expression */
+	EXPR_UNARY,			/**< Unary expression */
+	EXPR_BINARY,		/**< Binary expression */
+	EXPR_TERNARY,		/**< Ternary expression */
+	EXPR_LIST,			/**< Expression list */
+} expression_t;
+
+/** Value category */
+typedef enum VALUE
+{
+	LVALUE,				/**< An expression that designates an object */
+	RVALUE,				/**< An expression detached from any specific storage */
+} category_t;
+
+/**
+ *	Build a broken node
+ *
+ *	@return	Broken node
+ */
+inline node node_broken()
+{
+	return node_load(NULL, SIZE_MAX);
+}
+
+/**
+ *	Get expression class
+ *
+ *	@param	nd		Expression
+ *
+ *	@return	Expression class
+ */
+expression_t expression_get_class(const node *const nd);
+
+/**
+ *	Get expression type
+ *
+ *	@param	nd		Expression
+ *
+ *	@return	Expression type
+ */
+inline item_t expression_get_type(const node *const nd)
+{
+	return node_get_arg(nd, 0);
+}
+
+/**
+ *	Check if expression is lvalue
+ *
+ *	@param	nd		Expression
+ *
+ *	@return	@c 1 on true, @c 0 on false
+ */
+inline bool expression_is_lvalue(const node *const nd)
+{
+	return node_get_arg(nd, 1) == LVALUE;
+}
+
+/**
+ *	Get expression location
+ *
+ *	@param	nd		Expression
+ *
+ *	@return	Expression location
+ */
+inline location expression_get_location(const node *const nd)
+{
+	const size_t argc = node_get_argc(nd);
+	return (location){ (size_t)node_get_arg(nd, argc - 2), (size_t)node_get_arg(nd, argc - 1) };
+}
+
+/**
+ *	Get id of identifier expression
+ *
+ *	@param	nd		Identifier expression
+ *
+ *	@return	Id
+ */
+inline size_t identifier_expr_get_id(const node *const nd)
+{
+	return node_get_type(nd) == OP_IDENTIFIER ? (size_t)node_get_arg(nd, 2) : SIZE_MAX;
+}
+
+/**
+ *	Get integer value of literal expression
+ *
+ *	@param	nd		Literal expression
+ *
+ *	@return	Integer value
+ */
+inline int literal_expr_get_int(const node *const nd)
+{
+	return node_get_type(nd) == OP_LITERAL ? (int)node_get_arg(nd, 2) : INT_MAX;
+}
+
+/**
+ *	Get double value of literal expression
+ *
+ *	@param	nd		Literal expression
+ *
+ *	@return	Double value
+ */
+inline double literal_expr_get_double(const node *const nd)
+{
+	return node_get_type(nd) == OP_LITERAL ? node_get_arg_double(nd, 2) : DBL_MAX;
+}
+
+/**
+ *	Get string index of literal expression
+ *
+ *	@param	nd		Literal expression
+ *
+ *	@return	String index
+ */
+inline size_t literal_expr_get_string(const node *const nd)
+{
+	return node_get_type(nd) == OP_LITERAL ? (size_t)node_get_arg(nd, 2) : SIZE_MAX;
+}
+
+
+/**
+ *	Get base expression of subscript expression
+ *
+ *	@param	nd		Subscript expression
+ *
+ *	@return	Base expression
+ */
+inline node subscript_expr_get_base(const node *const nd)
+{
+	return node_get_type(nd) == OP_SLICE ? node_get_child(nd, 0) : node_broken();
+}
+
+/**
+ *	Get index expression of subscript expression
+ *
+ *	@param	nd		Subscript expression
+ *
+ *	@return	Index expression
+ */
+inline node subscript_expr_get_index(const node *const nd)
+{
+	return node_get_type(nd) == OP_SLICE ? node_get_child(nd, 1) : node_broken();
+}
+
+
+/**
+ *	Get called expression of call expression
+ *
+ *	@param	nd		Call expression
+ *
+ *	@return	Called expression
+ */
+inline node call_expr_get_callee(const node *const nd)
+{
+	return node_get_type(nd) == OP_CALL ? node_get_child(nd, 0) : node_broken();
+}
+
+/**
+ *	Get argument of call expression by index
+ *
+ *	@param	nd		Call expression
+ *	@param	index	Argument index
+ *
+ *	@return	Argument
+ */
+inline node call_expr_get_argument(const node *const nd, const size_t index)
+{
+	return node_get_type(nd) == OP_CALL ? node_get_child(nd, 1 + index) : node_broken();
+}
+
+
+/**
+ *	Get base expression of member expression
+ *
+ *	@param	nd		Member expression
+ *
+ *	@return	Base expression
+ */
+inline node member_expr_get_base(const node *const nd)
+{
+	return node_get_type(nd) == OP_SELECT ? node_get_child(nd, 0) : node_broken();
+}
+
+/**
+ *	Get member displacement of member expression
+ *
+ *	@param	nd		Member expression
+ *
+ *	@return	Member displacement
+ */
+inline size_t member_expr_get_member_displ(const node *const nd)
+{
+	return node_get_type(nd) == OP_SELECT ? (size_t)node_get_arg(nd, 2) : SIZE_MAX;
+}
+
+
+/**
+ *	Get operator of unary expression
+ *
+ *	@param	nd		Unary expression
+ *
+ *	@return	Operator
+ */
+inline unary_t unary_expr_get_operator(const node *const nd)
+{
+	return node_get_type(nd) == OP_UNARY ? (unary_t)node_get_arg(nd, 2) : INT_MAX;
+}
+
+/**
+ *	Get operand of unary expression
+ *
+ *	@param	nd		Unary expression
+ *
+ *	@return	Operand
+ */
+inline node unary_expr_get_operand(const node *const nd)
+{
+	return node_get_type(nd) == OP_UNARY ? node_get_child(nd, 0) : node_broken();
+}
+
+
+/**
+ *	Get operator of binary expression
+ *
+ *	@param	nd		Binary expression
+ *
+ *	@return	Operator
+ */
+inline binary_t binary_expr_get_operator(const node *const nd)
+{
+	return node_get_type(nd) == OP_BINARY ? (binary_t)node_get_arg(nd, 2) : INT_MAX;
+}
+
+/**
+ *	Get LHS of binary expression
+ *
+ *	@param	nd		Binary expression
+ *
+ *	@return	LHS of binary expression
+ */
+inline node binary_expr_get_LHS(const node *const nd)
+{
+	return node_get_type(nd) == OP_BINARY ? node_get_child(nd, 0) : node_broken();
+}
+
+/**
+ *	Get RHS of binary expression
+ *
+ *	@param	nd		Binary expression
+ *
+ *	@return	RHS of binary expression
+ */
+inline node binary_expr_get_RHS(const node *const nd)
+{
+	return node_get_type(nd) == OP_BINARY ? node_get_child(nd, 1) : node_broken();
+}
+
+
+/**
+ *	Get condition of ternary expression
+ *
+ *	@param	nd		Ternary expression
+ *
+ *	@return	Condition
+ */
+inline node ternary_expr_get_condition(const node *const nd)
+{
+	return node_get_type(nd) == OP_TERNARY ? node_get_child(nd, 0) : node_broken();
+}
+
+/**
+ *	Get LHS of ternary expression
+ *
+ *	@param	nd		Ternary expression
+ *
+ *	@return	LHS of ternary expression
+ */
+inline node ternary_expr_get_LHS(const node *const nd)
+{
+	return node_get_type(nd) == OP_TERNARY ? node_get_child(nd, 1) : node_broken();
+}
+
+/**
+ *	Get RHS of ternary expression
+ *
+ *	@param	nd		Ternary expression
+ *
+ *	@return	RHS of ternary expression
+ */
+inline node ternary_expr_get_RHS(const node *const nd)
+{
+	return node_get_type(nd) == OP_TERNARY ? node_get_child(nd, 2) : node_broken();
+}
+
+
+/**
+ *	Get size of expression list
+ *
+ *	@param	nd		Expression list
+ *
+ *	@return	Size
+ */
+inline size_t expression_list_get_size(const node *const nd)
+{
+	return node_get_type(nd) == OP_LIST ? node_get_amount(nd) : 0;
+}
+
+/**
+ *	Get expression of expression list by index
+ *
+ *	@param	nd		Expression list
+ *	@param	index	Expression index
+ *
+ *	@return	Expression
+ */
+inline node expression_list_get_subexpr(const node *const nd, const size_t index)
+{
+	return node_get_type(nd) == OP_LIST ? node_get_child(nd, index) : node_broken();
+}
+
+
+/** Statement kinds */
+typedef enum STATEMENT
+{
+	STMT_DECL,			/**< Declaration statement */
+	STMT_LABEL,			/**< Labeled statement */
+	STMT_CASE,			/**< Case statement */
+	STMT_DEFAULT,		/**< Default statement */
+	STMT_COMPOUND,		/**< Compound statement */
+	STMT_EXPR,			/**< Expression statement */
+	STMT_NULL,			/**< Null statement */
+	STMT_IF,			/**< If statement */
+	STMT_SWITCH,		/**< Switch statement */
+	STMT_WHILE,			/**< While statement */
+	STMT_DO,			/**< Do statement */
+	STMT_FOR,			/**< For statement */
+	STMT_GOTO,			/**< Goto statement */
+	STMT_CONTINUE,		/**< Continue statement */
+	STMT_BREAK,			/**< Break statement */
+	STMT_RETURN,		/**< Return statement */
+	STMT_PRINTF,		/**< Printf statement */
+} statement_t;
+
+
+/**
+ *	Get statement class
+ *
+ *	@param	nd		Statement
+ *
+ *	@return	Statement class
+ */
+statement_t statement_get_class(const node *const nd);
+
+
+/**
+ *	Get label id of labeled statement
+ *
+ *	@param	nd		Labeled statement
+ *
+ *	@return	Label id
+ */
+inline size_t labeled_stmt_get_label(const node *const nd)
+{
+	return node_get_type(nd) == OP_LABEL ? (size_t)node_get_arg(nd, 0) : SIZE_MAX;
+}
+
+/**
+ *	Get substatement of labeled statement
+ *
+ *	@param	nd		Labeled statement
+ *
+ *	@return	Substatement
+ */
+inline node labeled_stmt_get_substmt(const node *const nd)
+{
+	return node_get_type(nd) == OP_LABEL ? node_get_child(nd, 0) : node_broken();
+}
+
+
+/**
+ *	Get size of compound statement
+ *
+ *	@param	nd		Compound statement
+ *
+ *	@return	Size
+ */
+inline size_t compound_stmt_get_size(const node *const nd)
+{
+	return node_get_type(nd) == OP_BLOCK ? node_get_amount(nd) : SIZE_MAX;
+}
+
+/**
+ *	Get substatement of compound statement by index
+ *
+ *	@param	nd		Compound statement
+ *	@param	index	Substatement index
+ *
+ *	@return	Substatement
+ */
+inline node compound_stmt_get_substmt(const node *const nd, const size_t index)
+{
+	return node_get_type(nd) == OP_BLOCK ? node_get_child(nd, index) : node_broken();
+}
+
+
+/**
+ *	Check if if statement has else-substatement
+ *
+ *	@param	nd		If statement
+ *
+ *	@return	@c 1 on true, @c 0 on false
+ */
+inline bool if_stmt_has_else(const node *const nd)
+{
+	return node_get_type(nd) == OP_IF ? node_get_arg(nd, 0) != 0 : false;
+}
+
+/**
+ *	Get condition of if statement
+ *
+ *	@param	nd		If statement
+ *
+ *	@return	Condition
+ */
+inline node if_stmt_get_condition(const node *const nd)
+{
+	return node_get_type(nd) == OP_IF ? node_get_child(nd, 0) : node_broken();
+}
+
+/**
+ *	Get then-substatement of if statement
+ *
+ *	@param	nd		If statement
+ *
+ *	@return	Then-substatement
+ */
+inline node if_stmt_get_then_substmt(const node *const nd)
+{
+	return node_get_type(nd) == OP_IF ? node_get_child(nd, 1) : node_broken();
+}
+
+/**
+ *	Get else-substatement of if statement
+ *
+ *	@param	nd		If statement
+ *
+ *	@return	Else-substatement
+ */
+inline node if_stmt_get_else_substmt(const node *const nd)
+{
+	return if_stmt_has_else(nd) ? node_get_child(nd, 2) : node_broken();
+}
+
+
+/**
+ *	Get condition of while statement
+ *
+ *	@param	nd		While statement
+ *
+ *	@return	Condition
+ */
+inline node while_stmt_get_condition(const node *const nd)
+{
+	return node_get_type(nd) == OP_WHILE ? node_get_child(nd, 0) : node_broken();
+}
+
+/**
+ *	Get substatement of while statement
+ *
+ *	@param	nd		While statement
+ *
+ *	@return	Substatement
+ */
+inline node while_stmt_get_body(const node *const nd)
+{
+	return node_get_type(nd) == OP_WHILE ? node_get_child(nd, 1) : node_broken();
+}
+
+
+/**
+ *	Get condition of do statement
+ *
+ *	@param	nd		Do statement
+ *
+ *	@return	Condition
+ */
+inline node do_stmt_get_condition(const node *const nd)
+{
+	return node_get_type(nd) == OP_DO ? node_get_child(nd, 1) : node_broken();
+}
+
+/**
+ *	Get substatement of do statement
+ *
+ *	@param	nd		Do statement
+ *
+ *	@return	Substatement
+ */
+inline node do_stmt_get_body(const node *const nd)
+{
+	return node_get_type(nd) == OP_DO ? node_get_child(nd, 0) : node_broken();
+}
+
+
+/**
+ *	Check if for statement has inition
+ *
+ *	@param	nd		For statement
+ *
+ *	@return	@c 1 on true, @c 0 on false
+ */
+inline bool for_stmt_has_inition(const node *const nd)
+{
+	return node_get_type(nd) == OP_FOR ? node_get_arg(nd, 0) != 0 : false;
+}
+
+/**
+ *	Check if for statement has condition
+ *
+ *	@param	nd		For statement
+ *
+ *	@return	@c 1 on true, @c 0 on false
+ */
+inline bool for_stmt_has_condition(const node *const nd)
+{
+	return node_get_type(nd) == OP_FOR ? node_get_arg(nd, 1) != 0 : false;
+}
+
+/**
+ *	Check if for statement has increment
+ *
+ *	@param	nd		For statement
+ *
+ *	@return	@c 1 on true, @c 0 on false
+ */
+inline bool for_stmt_has_increment(const node *const nd)
+{
+	return node_get_type(nd) == OP_FOR ? node_get_arg(nd, 2) != 0 : false;
+}
+
+/**
+ *	Get inition of for statement
+ *
+ *	@param	nd		For statement
+ *
+ *	@return	Inition
+ */
+inline node for_stmt_get_inition(const node *const nd)
+{
+	return for_stmt_has_inition(nd) ? node_get_child(nd, 0) : node_broken();
+}
+
+/**
+ *	Get condition of for statement
+ *
+ *	@param	nd		For statement
+ *
+ *	@return	condition
+ */
+inline node for_stmt_get_condition(const node *const nd)
+{
+	return for_stmt_has_condition(nd)
+		? node_get_child(nd, for_stmt_has_inition(nd) ? 1 : 0)
+		: node_broken();
+}
+
+/**
+ *	Get increment of for statement
+ *
+ *	@param	nd		For statement
+ *
+ *	@return	Increment
+ */
+inline node for_stmt_get_increment(const node *const nd)
+{
+	return for_stmt_has_increment(nd)
+		? node_get_child(nd, node_get_amount(nd) - 2)
+		: node_broken();
+}
+
+/**
+ *	Get substatement of for statement
+ *
+ *	@param	nd		For statement
+ *
+ *	@return	Substatement
+ */
+inline node for_stmt_get_body(const node *const nd)
+{
+	return node_get_type(nd) == OP_FOR
+		? node_get_child(nd, node_get_amount(nd) - 1)
+		: node_broken();
+}
+
+
+/**
+ *	Get label id of goto statement
+ *
+ *	@param	nd		Goto statement
+ *
+ *	@return	Label id
+ */
+inline size_t goto_stmt_get_label(const node *const nd)
+{
+	return node_get_type(nd) == OP_GOTO ? (size_t)node_get_arg(nd, 0) : SIZE_MAX;
+}
+
+
+/**
+ *	Check if return statement has expression
+ *
+ *	@param	nd		Return statement
+ *
+ *	@return	@c 1 on true, @c 0 on false
+ */
+inline bool return_stmt_has_expression(const node *const nd)
+{
+	return node_get_type(nd) == OP_RETURN ? node_get_amount(nd) != 0 : false;
+}
+
+/**
+ *	Get expression of return statement
+ *
+ *	@param	nd		Return statement
+ *
+ *	@return	Expression
+ */
+inline node return_stmt_get_expression(const node *const nd)
+{
+	return return_stmt_has_expression(nd) ? node_get_child(nd, 0) : node_broken();
+}
+
+/**
+ *	Get argument count of printf statement
+ *
+ *	@param	nd		Printf statement
+ *
+ *	@return	Argument count
+ */
+inline size_t printf_stmt_get_argc(const node *const nd)
+{
+	return node_get_type(nd) == OP_PRINTF ? node_get_amount(nd) - 1 : 0;
+}
+
+/**
+ *	Get format string of printf statement
+ *
+ *	@param	nd		Printf statement
+ *
+ *	@return	Format string
+ */
+inline node printf_stmt_get_format_str(const node *const nd)
+{
+	return node_get_type(nd) == OP_PRINTF ? node_get_child(nd, 0) : node_broken();
+}
+
+/**
+ *	Get argument of printf statement
+ *
+ *	@param	nd		Printf statement
+ *
+ *	@return	Argument
+ */
+inline node printf_stmt_get_argument(const node *const nd, const size_t index)
+{
+	return printf_stmt_get_argc(nd) > index ? node_get_child(nd, 1 + index) : node_broken();
+}
+
+
+typedef enum DECLARATION
+{
+	DECL_VAR,			/**< Variable declaration */
+	DECL_FUNC,			/**< Function definition */
+	DECL_TYPE,			/**< Type declaration */
+} declaration_t;
+
+
+/**
+ *	Get declaration class
+ *
+ *	@param	nd		Declaration
+ *
+ *	@return	Declaration class
+ */
+declaration_t declaration_get_class(const node *const nd);
+
+
+/**
+ *	Get number of global declarations in translation unit
+ *
+ *	@param	nd		Translation unit
+ *
+ *	@return	Number of global declarations
+ */
+inline size_t translation_unit_get_size(const node *const nd)
+{
+	return node_is_correct(nd) && node_get_type(nd) == ITEM_MAX ? node_get_amount(nd) : SIZE_MAX;
+}
+
+/**
+ *	Get global declaration of translation unit by index
+ *
+ *	@param	nd		Translation unit
+ *	@param	index	Global declaration index
+ *
+ *	@return	Global declaration
+ */
+inline node translation_unit_get_declaration(const node *const nd, const size_t index)
+{
+	return node_is_correct(nd) && node_get_type(nd) == ITEM_MAX ? node_get_child(nd, index) : node_broken();
+}
+
+
+/**
+ *	Get variable id in variable declaration
+ *
+ *	@param	nd		Variable declaration
+ *
+ *	@return	Id
+ */
+inline size_t variable_decl_get_id(const node *const nd)
+{
+	return node_get_type(nd) == OP_DECL_VAR ? (size_t)node_get_arg(nd, 0) : SIZE_MAX;
+}
+
+/**
+ *	Check if variable declaration has initializer
+ *
+ *	@param	nd		Variable declaration
+ *
+ *	@return	@c 1 on true, @c 0 on false
+ */
+inline bool variable_decl_has_initializer(const node *const nd)
+{
+	return node_get_type(nd) == OP_DECL_VAR ? node_get_arg(nd, 2) != 0 : false;
+}
+
+/**
+ *	Get initializer of variable declaration
+ *
+ *	@param	nd		Variable declaration
+ *
+ *	@return	Initializer
+ */
+inline node variable_decl_get_initializer(const node *const nd)
+{
+	return variable_decl_has_initializer(nd) ? node_get_child(nd, node_get_amount(nd) - 1) : node_broken();
+}
+
+/**
+ *	Get amount of dimenstions of variable declaration
+ *
+ *	@param	nd		Variable declaration
+ *
+ *	@return	Amount of dimenstions
+ */
+inline size_t variable_decl_get_dim_amount(const node *const nd)
+{
+	return node_get_type(nd) == OP_DECL_VAR
+		? node_get_amount(nd) - (variable_decl_has_initializer(nd) ? 1 : 0)
+		: 0;
+}
+
+/**
+ *	Get size-expression of dimenstions of variable declaration by index
+ *
+ *	@param	nd		Variable declaration
+ *	@param	index	Dimansion index
+ *
+ *	@return	Size-expression
+ */
+inline node variable_decl_get_dim_expr(const node *const nd, const size_t index)
+{
+	return variable_decl_get_dim_amount(nd) > index ? node_get_child(nd, index) : node_broken();
+}
+
+
+/**
+ *	Get id of function in function declaration
+ *
+ *	@param	nd		Function declaration
+ *
+ *	@return Function id
+ */
+inline size_t function_decl_get_id(const node *const nd)
+{
+	return node_get_type(nd) == OP_FUNC_DEF ? (size_t)node_get_arg(nd, 0) : SIZE_MAX;
+}
+
+/**
+ *	Get parameter id in function declaration by index
+ *
+ *	@param	nd		Function declaration
+ *	@param	index	Parameter index
+ *
+ *	@return Parameter id
+ */
+size_t function_decl_get_param(const node *const nd, const size_t index);
+
+/**
+ *	Get body of function declaration
+ *
+ *	@param	nd		Function declaration
+ *
+ *	@return Function body
+ */
+inline node function_decl_get_body(const node *const nd)
+{
+	return node_get_type(nd) == OP_FUNC_DEF ? node_get_child(nd, node_get_amount(nd) - 1) : node_broken();
+}
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif

--- a/libs/compiler/AST.h
+++ b/libs/compiler/AST.h
@@ -25,6 +25,13 @@
 extern "C" {
 #endif
 
+/** Value category */
+typedef enum CATEGORY
+{
+	LVALUE,				/**< An expression that designates an object */
+	RVALUE,				/**< An expression detached from any specific storage */
+} category_t;
+
 /** Expression kinds */
 typedef enum EXPRESSION
 {
@@ -38,13 +45,6 @@ typedef enum EXPRESSION
 	EXPR_TERNARY,		/**< Ternary expression */
 	EXPR_LIST,			/**< Expression list */
 } expression_t;
-
-/** Value category */
-typedef enum CATEGORY
-{
-	LVALUE,				/**< An expression that designates an object */
-	RVALUE,				/**< An expression detached from any specific storage */
-} category_t;
 
 /** Statement kinds */
 typedef enum STATEMENT

--- a/libs/compiler/builder.c
+++ b/libs/compiler/builder.c
@@ -15,6 +15,7 @@
  */
 
 #include "builder.h"
+#include "AST.h"
 
 
 static node build_bin_op_node(syntax *const sx, node *const nd_left, node *const nd_right, const binary_t op_kind
@@ -74,12 +75,12 @@ static node build_assignment_expression(syntax *const sx, node *const nd_left, n
 		if (!expression_is_lvalue(nd_left))
 		{
 			semantic_error(sx, op_loc, unassignable);
-			return build_broken_expression();
+			return node_broken();
 		}
 
 		if (!check_assignment_operands(sx, left_type, nd_right))
 		{
-			return build_broken_expression();
+			return node_broken();
 		}
 	}
 
@@ -98,7 +99,7 @@ static node build_assignment_expression(syntax *const sx, node *const nd_left, n
 			if (!type_is_integer(left_type) || !type_is_integer(right_type))
 			{
 				semantic_error(sx, op_loc, typecheck_binary_expr);
-				return build_broken_expression();
+				return node_broken();
 			}
 
 			return build_bin_op_node(sx, nd_left, nd_right, op_kind, left_type);
@@ -112,14 +113,14 @@ static node build_assignment_expression(syntax *const sx, node *const nd_left, n
 			if (!type_is_arithmetic(left_type) || !type_is_arithmetic(right_type))
 			{
 				semantic_error(sx, op_loc, typecheck_binary_expr);
-				return build_broken_expression();
+				return node_broken();
 			}
 
 			return build_bin_op_node(sx, nd_left, nd_right, op_kind, left_type);
 		}
 
 		default:
-			return build_broken_expression();
+			return node_broken();
 	}
 }
 
@@ -387,7 +388,7 @@ static node fold_ternary_expression(node *const nd_left, node *const nd_middle, 
 static node build_bin_op_node(syntax *const sx, node *const nd_left, node *const nd_right, const binary_t op_kind
 	, const item_t result_type)
 {
-	if (node_get_type(nd_left) == OP_CONSTANT && node_get_type(nd_right) == OP_CONSTANT)
+	if (node_get_type(nd_left) == OP_LITERAL && node_get_type(nd_right) == OP_LITERAL)
 	{
 		return fold_binary_expression(sx, nd_left, nd_right, op_kind, result_type);
 	}
@@ -438,7 +439,7 @@ node build_identifier_expression(syntax *const sx, const size_t name, const loca
 	if (identifier == ITEM_MAX)
 	{
 		semantic_error(sx, loc, undeclared_var_use, repr_get_name(sx, name));
-		return build_broken_expression();
+		return node_broken();
 	}
 
 	const item_t type = ident_get_type(sx, (size_t)identifier);
@@ -456,24 +457,24 @@ node build_identifier_expression(syntax *const sx, const size_t name, const loca
 
 node build_integer_literal_expression(syntax *const sx, const int value, const location loc)
 {
-	node nd = node_create(sx, OP_CONSTANT);
-	node_add_arg(&nd, TYPE_INTEGER);				// Тип значения константы
-	node_add_arg(&nd, RVALUE);						// Категория значения константы
-	node_add_arg(&nd, value);						// Значение константы
-	node_add_arg(&nd, (item_t)loc.begin);			// Начальная позиция константы
-	node_add_arg(&nd, (item_t)loc.end);				// Конечная позиция константы
+	node nd = node_create(sx, OP_LITERAL);
+	node_add_arg(&nd, TYPE_INTEGER);				// Тип значения литерала
+	node_add_arg(&nd, RVALUE);						// Категория значения литерала
+	node_add_arg(&nd, value);						// Значение литерала
+	node_add_arg(&nd, (item_t)loc.begin);			// Начальная позиция литерала
+	node_add_arg(&nd, (item_t)loc.end);				// Конечная позиция литерала
 
 	return nd;
 }
 
 node build_floating_literal_expression(syntax *const sx, const double value, const location loc)
 {
-	node nd = node_create(sx, OP_CONSTANT);
-	node_add_arg(&nd, TYPE_FLOATING);				// Тип значения константы
-	node_add_arg(&nd, RVALUE);						// Категория значения константы
-	node_add_arg_double(&nd, value);				// Значение константы
-	node_add_arg(&nd, (item_t)loc.begin);			// Начальная позиция константы
-	node_add_arg(&nd, (item_t)loc.end);				// Конечная позиция константы
+	node nd = node_create(sx, OP_LITERAL);
+	node_add_arg(&nd, TYPE_FLOATING);				// Тип значения литерала
+	node_add_arg(&nd, RVALUE);						// Категория значения литерала
+	node_add_arg_double(&nd, value);				// Значение литерала
+	node_add_arg(&nd, (item_t)loc.begin);			// Начальная позиция литерала
+	node_add_arg(&nd, (item_t)loc.end);				// Конечная позиция литерала
 
 	return nd;
 }
@@ -482,11 +483,11 @@ node build_string_literal_expression(syntax *const sx, const size_t index, const
 {
 	const item_t type = type_array(sx, TYPE_INTEGER);
 
-	node nd = node_create(sx, OP_STRING);
-	node_add_arg(&nd, type);						// Тип строки
-	node_add_arg(&nd, LVALUE);						// Категория значения строки
+	node nd = node_create(sx, OP_LITERAL);
+	node_add_arg(&nd, type);						// Тип значения литерала
+	node_add_arg(&nd, LVALUE);						// Категория значения литерала
 	node_add_arg(&nd, (item_t)index);				// Индекс в списке строк
-	node_add_arg(&nd, (item_t)loc.begin);			// Начальная позиция строки
+	node_add_arg(&nd, (item_t)loc.begin);			// Начальная позиция литерала
 	node_add_arg(&nd, (item_t)loc.end);				// Конечная позиция строки
 
 	return nd;
@@ -494,11 +495,11 @@ node build_string_literal_expression(syntax *const sx, const size_t index, const
 
 node build_null_pointer_literal_expression(syntax *const sx, const location loc)
 {
-	node nd = node_create(sx, OP_CONSTANT);
-	node_add_arg(&nd, TYPE_NULL_POINTER);				// Тип константы
-	node_add_arg(&nd, RVALUE);						// Категория значения константы
-	node_add_arg(&nd, (item_t)loc.begin);			// Начальная позиция константы
-	node_add_arg(&nd, (item_t)loc.end);				// Конечная позиция константы
+	node nd = node_create(sx, OP_LITERAL);
+	node_add_arg(&nd, TYPE_NULL_POINTER);			// Тип значения литерала
+	node_add_arg(&nd, RVALUE);						// Категория значения литерала
+	node_add_arg(&nd, (item_t)loc.begin);			// Начальная позиция литерала
+	node_add_arg(&nd, (item_t)loc.end);				// Конечная позиция литерала
 
 	return nd;
 }
@@ -508,21 +509,21 @@ node build_subscript_expression(syntax *const sx, const node *const nd_fst, cons
 {
 	if (!node_is_correct(nd_fst) || !node_is_correct(nd_snd))
 	{
-		return build_broken_expression();
+		return node_broken();
 	}
 
 	const item_t base_type = expression_get_type(nd_fst);
 	if (!type_is_array(sx, base_type))
 	{
 		semantic_error(sx, l_loc, typecheck_subscript_value);
-		return build_broken_expression();
+		return node_broken();
 	}
 
 	const item_t index_type = expression_get_type(nd_snd);
 	if (!type_is_integer(index_type))
 	{
 		semantic_error(sx, expression_get_location(nd_snd), typecheck_subscript_not_integer);
-		return build_broken_expression();
+		return node_broken();
 	}
 
 	const item_t element_type = type_array_get_element_type(sx, base_type);
@@ -544,14 +545,14 @@ node build_call_expression(syntax *const sx, const node *const nd_func, const no
 {
 	if (!node_is_correct(nd_func))
 	{
-		return build_broken_expression();
+		return node_broken();
 	}
 
 	const item_t operand_type = expression_get_type(nd_func);
 	if (!type_is_function(sx, operand_type))
 	{
 		semantic_error(sx, l_loc, typecheck_call_not_function);
-		return build_broken_expression();
+		return node_broken();
 	}
 
 	const size_t expected_args = type_function_get_parameter_amount(sx, operand_type);
@@ -560,7 +561,7 @@ node build_call_expression(syntax *const sx, const node *const nd_func, const no
 	if (expected_args != actual_args)
 	{
 		semantic_error(sx, r_loc, wrong_number_of_params, expected_args, actual_args);
-		return build_broken_expression();
+		return node_broken();
 	}
 
 	for (size_t i = 0; i < actual_args; i++)
@@ -568,13 +569,13 @@ node build_call_expression(syntax *const sx, const node *const nd_func, const no
 		const node nd_argument = node_vector_get(args, i);
 		if (!node_is_correct(&nd_argument))
 		{
-			return build_broken_expression();
+			return node_broken();
 		}
 
 		const item_t expected_type = type_function_get_parameter_type(sx, operand_type, i);
 		if (!check_assignment_operands(sx, expected_type, &nd_argument))
 		{
-			return build_broken_expression();
+			return node_broken();
 		}
 	}
 
@@ -601,7 +602,7 @@ node build_member_expression(syntax *const sx, const node *const nd_base, const 
 {
 	if (!node_is_correct(nd_base))
 	{
-		return build_broken_expression();
+		return node_broken();
 	}
 
 	const item_t operand_type = expression_get_type(nd_base);
@@ -613,7 +614,7 @@ node build_member_expression(syntax *const sx, const node *const nd_base, const 
 		if (!type_is_structure(sx, operand_type))
 		{
 			semantic_error(sx, op_loc, typecheck_member_reference_struct);
-			return build_broken_expression();
+			return node_broken();
 		}
 
 		struct_type = operand_type;
@@ -624,7 +625,7 @@ node build_member_expression(syntax *const sx, const node *const nd_base, const 
 		if (!type_is_struct_pointer(sx, operand_type))
 		{
 			semantic_error(sx, op_loc, typecheck_member_reference_arrow);
-			return build_broken_expression();
+			return node_broken();
 		}
 
 		struct_type = type_pointer_get_element_type(sx, operand_type);
@@ -655,28 +656,28 @@ node build_member_expression(syntax *const sx, const node *const nd_base, const 
 	}
 
 	semantic_error(sx, id_loc, no_member, repr_get_name(sx, name));
-	return build_broken_expression();
+	return node_broken();
 }
 
 node build_upb_expression(syntax *const sx, const node *const nd_fst, const node *const nd_snd)
 {
 	if (!node_is_correct(nd_fst) || !node_is_correct(nd_snd))
 	{
-		return build_broken_expression();
+		return node_broken();
 	}
 
 	const item_t fst_type = expression_get_type(nd_fst);
 	if (!type_is_integer(fst_type))
 	{
 		semantic_error(sx, expression_get_location(nd_fst), not_int_in_stanfunc);
-		return build_broken_expression();
+		return node_broken();
 	}
 
 	const item_t snd_type = expression_get_type(nd_snd);
 	if (!type_is_array(sx, snd_type))
 	{
 		semantic_error(sx, expression_get_location(nd_snd), not_array_in_stanfunc);
-		return build_broken_expression();
+		return node_broken();
 	}
 
 	node nd = node_create(sx, OP_UPB);
@@ -694,7 +695,7 @@ node build_unary_expression(syntax *const sx, node *const nd_operand, const unar
 {
 	if (!node_is_correct(nd_operand))
 	{
-		return build_broken_expression();
+		return node_broken();
 	}
 
 	const item_t operand_type = expression_get_type(nd_operand);
@@ -715,13 +716,13 @@ node build_unary_expression(syntax *const sx, node *const nd_operand, const unar
 			if (!type_is_arithmetic(operand_type))
 			{
 				semantic_error(sx, op_loc, typecheck_illegal_increment, op_kind);
-				return build_broken_expression();
+				return node_broken();
 			}
 
 			if (!expression_is_lvalue(nd_operand))
 			{
 				semantic_error(sx, op_loc, typecheck_expression_not_lvalue);
-				return build_broken_expression();
+				return node_broken();
 			}
 
 			result_type = operand_type;
@@ -733,7 +734,7 @@ node build_unary_expression(syntax *const sx, node *const nd_operand, const unar
 			if (!expression_is_lvalue(nd_operand))
 			{
 				semantic_error(sx, op_loc, typecheck_invalid_lvalue_addrof);
-				return build_broken_expression();
+				return node_broken();
 			}
 
 			result_type = type_pointer(sx, operand_type);
@@ -745,7 +746,7 @@ node build_unary_expression(syntax *const sx, node *const nd_operand, const unar
 			if (!type_is_pointer(sx, operand_type))
 			{
 				semantic_error(sx, op_loc, typecheck_indirection_requires_pointer);
-				return build_broken_expression();
+				return node_broken();
 			}
 
 			result_type = type_pointer_get_element_type(sx, operand_type);
@@ -760,7 +761,7 @@ node build_unary_expression(syntax *const sx, node *const nd_operand, const unar
 			if (!type_is_arithmetic(operand_type))
 			{
 				semantic_error(sx, op_loc, typecheck_unary_expr, operand_type);
-				return build_broken_expression();
+				return node_broken();
 			}
 
 			result_type = operand_type;
@@ -772,7 +773,7 @@ node build_unary_expression(syntax *const sx, node *const nd_operand, const unar
 			if (!type_is_integer(operand_type))
 			{
 				semantic_error(sx, op_loc, typecheck_unary_expr, operand_type);
-				return build_broken_expression();
+				return node_broken();
 			}
 
 			result_type = TYPE_INTEGER;
@@ -784,7 +785,7 @@ node build_unary_expression(syntax *const sx, node *const nd_operand, const unar
 			if (!type_is_scalar(sx, operand_type))
 			{
 				semantic_error(sx, op_loc, typecheck_unary_expr, operand_type);
-				return build_broken_expression();
+				return node_broken();
 			}
 
 			result_type = TYPE_INTEGER;
@@ -796,7 +797,7 @@ node build_unary_expression(syntax *const sx, node *const nd_operand, const unar
 		? (location){ op_loc.begin, expression_get_location(nd_operand).end }
 		: (location){ expression_get_location(nd_operand).begin, op_loc.end };
 
-	if (node_get_type(nd_operand) == OP_CONSTANT)
+	if (node_get_type(nd_operand) == OP_LITERAL)
 	{
 		return fold_unary_expression(sx, op_kind, nd_operand);
 	}
@@ -817,7 +818,7 @@ node build_binary_expression(syntax *const sx, node *const nd_left, node *const 
 {
 	if (!node_is_correct(nd_left) || !node_is_correct(nd_right))
 	{
-		return build_broken_expression();
+		return node_broken();
 	}
 
 	if (operation_is_assignment(op_kind))
@@ -840,7 +841,7 @@ node build_binary_expression(syntax *const sx, node *const nd_left, node *const 
 			if (!type_is_integer(left_type) || !type_is_integer(right_type))
 			{
 				semantic_error(sx, op_loc, typecheck_binary_expr);
-				return build_broken_expression();
+				return node_broken();
 			}
 
 			return build_bin_op_node(sx, nd_left, nd_right, op_kind, TYPE_INTEGER);
@@ -854,7 +855,7 @@ node build_binary_expression(syntax *const sx, node *const nd_left, node *const 
 			if (!type_is_arithmetic(left_type) || !type_is_arithmetic(right_type))
 			{
 				semantic_error(sx, op_loc, typecheck_binary_expr);
-				return build_broken_expression();
+				return node_broken();
 			}
 
 			const item_t result_type = usual_arithmetic_conversions(left_type, right_type);
@@ -869,7 +870,7 @@ node build_binary_expression(syntax *const sx, node *const nd_left, node *const 
 			if (!type_is_arithmetic(left_type) || !type_is_arithmetic(right_type))
 			{
 				semantic_error(sx, op_loc, typecheck_binary_expr);
-				return build_broken_expression();
+				return node_broken();
 			}
 
 			return build_bin_op_node(sx, nd_left, nd_right, op_kind, TYPE_INTEGER);
@@ -881,7 +882,7 @@ node build_binary_expression(syntax *const sx, node *const nd_left, node *const 
 			if (!type_is_scalar(sx, left_type) || !type_is_scalar(sx, right_type))
 			{
 				semantic_error(sx, op_loc, typecheck_binary_expr);
-				return build_broken_expression();
+				return node_broken();
 			}
 
 			return build_bin_op_node(sx, nd_left, nd_right, op_kind, TYPE_INTEGER);
@@ -904,14 +905,14 @@ node build_binary_expression(syntax *const sx, node *const nd_left, node *const 
 			}
 
 			semantic_error(sx, op_loc, typecheck_binary_expr);
-			return build_broken_expression();
+			return node_broken();
 		}
 
 		case BIN_COMMA:
 			return build_bin_op_node(sx, nd_left, nd_right, op_kind, right_type);
 
 		default:
-			return build_broken_expression();
+			return node_broken();
 	}
 }
 
@@ -920,7 +921,7 @@ node build_ternary_expression(syntax *const sx, node *const nd_left, node *const
 {
 	if (!node_is_correct(nd_left) || !node_is_correct(nd_middle) || !node_is_correct(nd_right))
 	{
-		return build_broken_expression();
+		return node_broken();
 	}
 
 	const item_t left_type = expression_get_type(nd_left);
@@ -930,7 +931,7 @@ node build_ternary_expression(syntax *const sx, node *const nd_left, node *const
 	if (!type_is_scalar(sx, left_type))
 	{
 		semantic_error(sx, expression_get_location(nd_left), typecheck_statement_requires_scalar);
-		return build_broken_expression();
+		return node_broken();
 	}
 
 	item_t result_type = middle_type;
@@ -943,10 +944,10 @@ node build_ternary_expression(syntax *const sx, node *const nd_left, node *const
 	else if (middle_type != right_type)
 	{
 		semantic_error(sx, op_loc, typecheck_cond_incompatible_operands);
-		return build_broken_expression();
+		return node_broken();
 	}
 
-	if (node_get_type(nd_left) == OP_CONSTANT)
+	if (node_get_type(nd_left) == OP_LITERAL)
 	{
 		return fold_ternary_expression(nd_left, nd_middle, nd_right);
 	}
@@ -970,7 +971,7 @@ node build_init_list_expression(syntax *const sx, const node_vector *vec, const 
 	if (actual_inits == 0)
 	{
 		semantic_error(sx, l_loc, empty_init);
-		return build_broken_expression();
+		return node_broken();
 	}
 
 	if (type_is_structure(sx, type))
@@ -980,7 +981,7 @@ node build_init_list_expression(syntax *const sx, const node_vector *vec, const 
 		if (expected_inits != actual_inits)
 		{
 			semantic_error(sx, r_loc, wrong_init_in_actparam, expected_inits, actual_inits);
-			return build_broken_expression();
+			return node_broken();
 		}
 
 		for (size_t i = 0; i < actual_inits; i++)
@@ -988,13 +989,13 @@ node build_init_list_expression(syntax *const sx, const node_vector *vec, const 
 			const node nd_initializer = node_vector_get(vec, i);
 			if (!node_is_correct(&nd_initializer))
 			{
-				return build_broken_expression();
+				return node_broken();
 			}
 
 			const item_t expected_type = type_structure_get_member_type(sx, type, i);
 			if (!check_assignment_operands(sx, expected_type, &nd_initializer))
 			{
-				return build_broken_expression();
+				return node_broken();
 			}
 		}
 	}
@@ -1006,19 +1007,19 @@ node build_init_list_expression(syntax *const sx, const node_vector *vec, const 
 			const node nd_initializer = node_vector_get(vec, i);
 			if (!node_is_correct(&nd_initializer))
 			{
-				return build_broken_expression();
+				return node_broken();
 			}
 
 			if (!check_assignment_operands(sx, expected_type, &nd_initializer))
 			{
-				return build_broken_expression();
+				return node_broken();
 			}
 		}
 	}
 	else
 	{
 		semantic_error(sx, l_loc, wrong_init);
-		return build_broken_expression();
+		return node_broken();
 	}
 
 	node nd = node_create(sx, OP_LIST);
@@ -1033,9 +1034,4 @@ node build_init_list_expression(syntax *const sx, const node_vector *vec, const 
 	}
 
 	return nd;
-}
-
-node build_broken_expression()
-{
-	return node_load(NULL, SIZE_MAX);
 }

--- a/libs/compiler/builder.h
+++ b/libs/compiler/builder.h
@@ -202,13 +202,6 @@ node build_ternary_expression(syntax *const sx, node *const nd_left, node *const
 node build_init_list_expression(syntax *const sx, const node_vector *vec, const item_t type
 	, const location l_loc, const location r_loc);
 
-/**
- *	Build a broken expression
- *
- *	@return	Broken expression node
- */
-node build_broken_expression();
-
 #ifdef __cplusplus
 } /* extern "C" */
 #endif

--- a/libs/compiler/codes.c
+++ b/libs/compiler/codes.c
@@ -58,7 +58,7 @@ static size_t elem_get_name(const item_t elem, const size_t num, char *const buf
 					break;
 			}
 			break;
-		case OP_CONSTANT:
+		case OP_LITERAL:
 			argc = 3;
 			was_switch = true;
 			switch (num)
@@ -74,25 +74,6 @@ static size_t elem_get_name(const item_t elem, const size_t num, char *const buf
 					break;
 				case 3:
 					sprintf(buffer, "value");
-					break;
-			}
-			break;
-		case OP_STRING:
-			argc = 3;
-			was_switch = true;
-			switch (num)
-			{
-				case 0:
-					sprintf(buffer, "STRING");
-					break;
-				case 1:
-					sprintf(buffer, "type");
-					break;
-				case 2:
-					sprintf(buffer, "designation");
-					break;
-				case 3:
-					sprintf(buffer, "index");
 					break;
 			}
 			break;
@@ -809,15 +790,6 @@ static size_t elem_to_io(universal_io *const io, const vector *const table, size
 	}
 	uni_printf(io, "\n");
 
-	if (type == OP_STRING)
-	{
-		const size_t n = (size_t)vector_get(table, i - 1);
-		for (size_t j = 0; j < n; j++)
-		{
-			uni_printf(io, "%" PRIitem "\n", vector_get(table, i++));
-		}
-	}
-
 	return i;
 }
 
@@ -855,7 +827,7 @@ static size_t tree_print_recursive(universal_io *const io, node *const nd, size_
 		}
 		uni_printf(io, "\n");
 
-		if ((node_get_arg(nd, i) != ITEM_MAX && node_get_type(nd) != OP_STRING) || i != argc)
+		if ((node_get_arg(nd, i) != ITEM_MAX) || i != argc)
 		{
 			elem_get_name(type, 0, buffer);
 			//warning(NULL, node_argc, index, buffer);

--- a/libs/compiler/operations.h
+++ b/libs/compiler/operations.h
@@ -102,8 +102,7 @@ typedef enum OPERATION
 	
 	// Expressions
 	OP_IDENTIFIER,			/**< Identifier node */
-	OP_CONSTANT,			/**< Constant node */
-	OP_STRING,				/**< String litaral node */
+	OP_LITERAL,				/**< Literal node */
 	OP_CALL,				/**< Call node */
 	OP_SELECT,				/**< Select operator node */
 	OP_SLICE,				/**< Slice operator node */
@@ -195,9 +194,9 @@ typedef enum builtin
 	BI_FPUTC				= 154,
 	BI_FCLOSE				= 158,
 
-	BI_EXIT					= 146,
+	BI_EXIT					= 162,
 
-	BEGIN_USER_FUNC			= 150,
+	BEGIN_USER_FUNC			= 166,
 } builtin_t;
 
 

--- a/libs/compiler/parser.h
+++ b/libs/compiler/parser.h
@@ -17,6 +17,7 @@
 #pragma once
 
 #include <stdbool.h>
+#include "AST.h"
 #include "builder.h"
 #include "errors.h"
 #include "lexer.h"

--- a/libs/compiler/parser_expr.c
+++ b/libs/compiler/parser_expr.c
@@ -170,7 +170,7 @@ static node parse_primary_expression(parser *const prs)
 			if (!token_try_consume(prs, TK_R_PAREN))
 			{
 				parser_error(prs, expected_r_paren, l_loc);
-				return build_broken_expression();
+				return node_broken();
 			}
 
 			return nd_result;
@@ -178,7 +178,7 @@ static node parse_primary_expression(parser *const prs)
 
 		default:
 			parser_error(prs, expected_expression);
-			return build_broken_expression();
+			return node_broken();
 	}
 }
 
@@ -265,7 +265,7 @@ static node parse_postfix_expression(parser *const prs)
 					parser_error(prs, expected_r_square, l_loc);
 					token_skip_until(prs, TK_R_SQUARE | TK_SEMICOLON);
 					token_try_consume(prs, TK_R_SQUARE);
-					nd_operand = build_broken_expression();
+					nd_operand = node_broken();
 				}
 
 				continue;
@@ -294,7 +294,7 @@ static node parse_postfix_expression(parser *const prs)
 					parser_error(prs, expected_r_paren, l_loc);
 					token_skip_until(prs, TK_R_PAREN | TK_SEMICOLON);
 					token_try_consume(prs, TK_R_PAREN);
-					nd_operand = build_broken_expression();
+					nd_operand = node_broken();
 				}
 
 				node_vector_clear(&args);
@@ -317,7 +317,7 @@ static node parse_postfix_expression(parser *const prs)
 				else
 				{
 					parser_error(prs, expected_identifier);
-					nd_operand = build_broken_expression();
+					nd_operand = node_broken();
 				}
 
 				continue;
@@ -411,7 +411,7 @@ static node parse_RHS_of_binary_expression(parser *const prs, node *const LHS, c
 		location op_loc = token_consume(prs);
 
 		bool is_binary = true;
-		node middle = build_broken_expression();
+		node middle = node_broken();
 		if (next_token_prec == PREC_CONDITIONAL)
 		{
 			is_binary = false;
@@ -493,7 +493,7 @@ node parse_initializer(parser *const prs, const item_t type)
 		{
 			token_consume(prs);
 			parser_error(prs, empty_init);
-			return build_broken_expression();
+			return node_broken();
 		}
 
 		node_vector inits = parse_expression_list(prs, type);
@@ -508,7 +508,7 @@ node parse_initializer(parser *const prs, const item_t type)
 			parser_error(prs, expected_r_brace, l_loc);
 			token_skip_until(prs, TK_R_BRACE | TK_SEMICOLON);
 			token_try_consume(prs, TK_R_BRACE);
-			nd_result = build_broken_expression();
+			nd_result = node_broken();
 		}
 
 		node_vector_clear(&inits);

--- a/libs/compiler/syntax.c
+++ b/libs/compiler/syntax.c
@@ -28,11 +28,6 @@ static const size_t TYPES_SIZE = 1000;
 static const size_t TREE_SIZE = 10000;
 
 
-extern item_t expression_get_type(const node *const nd);
-extern bool expression_is_lvalue(const node *const nd);
-extern location expression_get_location(const node *const nd);
-
-
 static void repr_add_keyword(map *const reprtab, const char32_t *const eng, const char32_t *const rus, const token_t token)
 {
 	char32_t buffer[MAX_STRING_LENGTH];

--- a/libs/compiler/syntax.h
+++ b/libs/compiler/syntax.h
@@ -52,13 +52,6 @@ enum TYPE
 	TYPE_POINTER,
 };
 
-/** Value category */
-typedef enum VALUE
-{
-	LVALUE,		/**< An expression that designates an object */
-	RVALUE,		/**< An expression detached from any specific storage */
-} category_t;
-
 
 typedef struct location
 {
@@ -677,44 +670,6 @@ item_t scope_func_enter(syntax *const sx);
  *	@return	Max displacement of the function, @c ITEM_MAX on failure
  */
 item_t scope_func_exit(syntax *const sx, const item_t displ);
-
-
-/**
- *	Get expression type
- *
- *	@param	nd	Expression
- *
- *	@return	Expression type
- */
-inline item_t expression_get_type(const node *const nd)
-{
-	return node_get_arg(nd, 0);
-}
-
-/**
- *	Check if expression is lvalue
- *
- *	@param	nd	Expression for check
- *
- *	@return	@c 1 on true, @c 0 on false
- */
-inline bool expression_is_lvalue(const node *const nd)
-{
-	return node_get_arg(nd, 1) == LVALUE;
-}
-
-/**
- *	Get expression location
- *
- *	@param	nd	Expression
- *
- *	@return	Expression location
- */
-inline location expression_get_location(const node *const nd)
-{
-	const size_t argc = node_get_argc(nd);
-	return (location){ (size_t)node_get_arg(nd, argc - 2), (size_t)node_get_arg(nd, argc - 1) };
-}
 
 #ifdef __cplusplus
 } /* extern "C" */


### PR DESCRIPTION
- Реализован интерфейс синтаксического дерева. В нем пока не хватает интерфейса для чтения типов и операторов case/default/switch, будут добавлены позже.
- Узел строки превращен в узел литерала
- Типы узлов разделены на три группы выражений, операторов и объявлений. Это позволяет не использовать default и не рассчитывать на то, что узлы выражений и операторов будут равноправными в дереве. Пример функции генерации операторов:
```c
static void emit_statement(information *const info, const node *const nd)
{
	switch (statement_get_class(nd))
	{
		case STMT_DECL:
			emit_declaration(info, nd);
			return;

		case STMT_LABEL:
			emit_labeled_statement(info, nd);
			return;

		case STMT_CASE:
			// TODO: case statement emission
			// emit_case_statement(info, nd);
			return;

		case STMT_DEFAULT:
			// TODO: default statement emission
			// emit_default_statement(info, nd);
			return;

		case STMT_COMPOUND:
			emit_compound_statement(info, nd);
			return;

		case STMT_EXPR:
			emit_expression(info, nd);
			return;

		case STMT_NULL:
			return;

		case STMT_IF:
			emit_if_statement(info, nd);
			return;

		case STMT_SWITCH:
			// TODO: switch statement emission
			// emit_switch_statement(info, nd);
			return;

		case STMT_WHILE:
			emit_while_statement(info, nd);
			return;

		case STMT_DO:
			emit_do_statement(info, nd);
			return;

		case STMT_FOR:
			emit_for_statement(info, nd);
			return;

		case STMT_GOTO:
			to_code_unconditional_branch(info, (item_t)goto_stmt_get_label(nd));
			return;

		case STMT_CONTINUE:
			to_code_unconditional_branch(info, info->label_continue);
			return;

		case STMT_BREAK:
			to_code_unconditional_branch(info, info->label_break);
			return;

		case STMT_RETURN:
			emit_return_statement(info, nd);
			return;

		case STMT_PRINTF:
			emit_printf_statement(info, nd);
			return;
	}
}
```

Честно не знаю, что делать с функцией сломанного узла. Она используется в интерфейсе дерева, и логичнее, если она там будет, но тогда она должна по-другому называться, так как префикса `build` там быть не должно. При этом это теперь не только выражение, но и любая конструкция языка.
