### PR TITLE
Структуры и подтягивание изменений из парсера

### DIFF
--- a/libs/compiler/llvmgen.c
+++ b/libs/compiler/llvmgen.c
@@ -1196,20 +1196,18 @@ static void expression(information *const info, node *const nd)
 
 			item_t type = node_get_arg(nd, 0);
 			const item_t displ = ident_get_displ(info->sx, (size_t)node_get_arg(nd, 2));
-			node_set_next(nd);
 
-			bool is_pointer = false;
-			if (type_is_pointer(info->sx, type))
+			const bool is_pointer = type_is_pointer(info->sx, type);
+			if (is_pointer)
 			{
-				to_code_load(info, info->register_num, displ, type, false);
-				info->register_num++;
+				to_code_load(info, info->register_num++, displ, type, false);
 				type = type_pointer_get_element_type(info->sx, type);
-				is_pointer = true;
 			}
 
-			uni_printf(info->sx->io, " %%.%" PRIitem " = getelementptr inbounds %%struct_opt.%" PRIitem ", " 
-				"%%struct_opt.%" PRIitem "* %%%s.%" PRIitem ", i32 0, i32 %" PRIitem "\n", info->register_num, type, type
-				, is_pointer ? "" : "var", is_pointer ? info->register_num - 1 : displ, place);
+			uni_printf(info->sx->io, " %%.%" PRIitem " = getelementptr inbounds %%struct_opt.%" PRIitem 
+				", %%struct_opt.%" PRIitem "* %%%s.%" PRIitem ", i32 0, i32 %" PRIitem "\n"
+				, info->register_num, type, type, is_pointer ? "" : "var"
+				, is_pointer ? info->register_num - 1 : displ, place);
 
 			if (info->variable_location != LMEM)
 			{
@@ -1219,6 +1217,7 @@ static void expression(information *const info, node *const nd)
 			}
 
 			info->answer_reg = info->register_num++;
+			node_set_next(nd);
 		}
 		break;
 			
@@ -1855,8 +1854,6 @@ static void builin_functions_declaration(information *const info)
 			for (size_t j = 0; j < parameters; j++)
 			{
 				uni_printf(info->sx->io, j == 0 ? "" : ", ");
-
-				item_t param_type = type_function_get_parameter_type(info->sx, func_type, j);
 				
 				// TODO: будет исправлено, когда будет введён тип char
 				if (i == BI_FOPEN)
@@ -1865,7 +1862,7 @@ static void builin_functions_declaration(information *const info)
 				}
 				else
 				{				
-					type_to_io(info, param_type);
+					type_to_io(info, type_function_get_parameter_type(info->sx, func_type, j));
 				}
 			}
 			uni_printf(info->sx->io, ")\n");

--- a/libs/compiler/llvmgen.c
+++ b/libs/compiler/llvmgen.c
@@ -79,8 +79,8 @@ typedef struct information
 	bool was_printf;						/**< Истина, если вызывался printf в исходном коде */
 	bool was_dynamic;						/**< Истина, если в функции были динамические массивы */
 	bool was_file;							/**< Истина, если была работа с файлами */
-	bool was_abs;							/**< Истина, если был вызов abs*/
-	bool was_fabs;							/**< Истина, если был вызов fabs*/
+	bool was_abs;							/**< Истина, если был вызов abs */
+	bool was_fabs;							/**< Истина, если был вызов fabs */
 	bool was_function[BEGIN_USER_FUNC];		/**< Массив флагов библиотечных функций из builtin_t */
 } information;
 
@@ -664,7 +664,7 @@ static void integral_expression(information *const info, node *const nd, const a
 	{
 		to_code_operation_reg_null(info, operation, left_reg, operation_type);
 	}
-		else if (left_kind == ANULL && right_kind == AREG)
+	else if (left_kind == ANULL && right_kind == AREG)
 	{
 		to_code_operation_null_reg(info, operation, right_reg, operation_type);
 	}
@@ -1110,6 +1110,7 @@ static void expression(information *const info, node *const nd)
 				arguments_type[i] = info->answer_kind;
 				arguments_value_type[i] = type_function_get_parameter_type(info->sx, type_ref, i);
 				to_code_try_widen(info, arguments_value_type[i], answer_type);
+
 				if (info->answer_kind == AREG)
 				{
 					arguments[i] = info->answer_reg;

--- a/libs/compiler/llvmgen.c
+++ b/libs/compiler/llvmgen.c
@@ -1887,7 +1887,6 @@ int encode_to_llvm(const workspace *const ws, syntax *const sx)
 	{
 		return -1;
 	}
-	tables_and_tree("tree.txt", &(sx->identifiers), &(sx->types), &(sx->tree));
 
 	information info;
 	info.sx = sx;

--- a/libs/compiler/llvmgen.c
+++ b/libs/compiler/llvmgen.c
@@ -1201,12 +1201,22 @@ static void expression(information *const info, node *const nd)
 			const item_t elem_type = node_get_arg(nd, 0);
 			node_set_next(nd);
 
-			const item_t type = node_get_arg(nd, 0);
+			item_t type = node_get_arg(nd, 0);
 			const item_t displ = ident_get_displ(info->sx, (size_t)node_get_arg(nd, 2));
 			node_set_next(nd);
 
+			bool is_pointer = false;
+			if (type_is_pointer(info->sx, type))
+			{
+				to_code_load(info, info->register_num, displ, type, false);
+				info->register_num++;
+				type = type_pointer_get_element_type(info->sx, type);
+				is_pointer = true;
+			}
+
 			uni_printf(info->sx->io, " %%.%" PRIitem " = getelementptr inbounds %%struct_opt.%" PRIitem ", " 
-				"%%struct_opt.%" PRIitem "* %%var.%" PRIitem ", i32 0, i32 %" PRIitem "\n", info->register_num, type, type, displ, place);
+				"%%struct_opt.%" PRIitem "* %%%s.%" PRIitem ", i32 0, i32 %" PRIitem "\n", info->register_num, type, type
+				, is_pointer ? "" : "var", is_pointer ? info->register_num - 1 : displ, place);
 
 			if (info->variable_location != LMEM)
 			{

--- a/libs/compiler/llvmgen.c
+++ b/libs/compiler/llvmgen.c
@@ -1198,6 +1198,7 @@ static void expression(information *const info, node *const nd)
 		case OP_SELECT:
 		{
 			const item_t place = node_get_arg(nd, 2);
+			const item_t elem_type = node_get_arg(nd, 0);
 			node_set_next(nd);
 
 			const item_t type = node_get_arg(nd, 0);
@@ -1210,7 +1211,7 @@ static void expression(information *const info, node *const nd)
 			if (info->variable_location != LMEM)
 			{
 				info->register_num++;
-				to_code_load(info, info->register_num, info->register_num - 1, TYPE_INTEGER, true);
+				to_code_load(info, info->register_num, info->register_num - 1, elem_type, true);
 				info->answer_kind = AREG;
 			}
 

--- a/libs/compiler/llvmgen.c
+++ b/libs/compiler/llvmgen.c
@@ -142,10 +142,6 @@ static void type_to_io(information *const info, const item_t type)
 		uni_printf(info->sx->io, "%%struct._IO_FILE");
 		info->was_file = true;
 	}
-	else if (type_is_undefined(type))
-	{
-		uni_printf(info->sx->io, "i8*");
-	}
 }
 
 static void operation_to_io(universal_io *const io, const item_t operation_type, const item_t type)
@@ -1861,12 +1857,16 @@ static void builin_functions_declaration(information *const info)
 				uni_printf(info->sx->io, j == 0 ? "" : ", ");
 
 				item_t param_type = type_function_get_parameter_type(info->sx, func_type, j);
-				// TODO: как исправить этот костыль???
+				
+				// TODO: будет исправлено, когда будет введён тип char
 				if (i == BI_FOPEN)
 				{
-					param_type = TYPE_UNDEFINED;
+					uni_printf(info->sx->io, "i8*");
 				}
-				type_to_io(info, param_type);
+				else
+				{				
+					type_to_io(info, param_type);
+				}
 			}
 			uni_printf(info->sx->io, ")\n");
 		}

--- a/libs/compiler/llvmgen.h
+++ b/libs/compiler/llvmgen.h
@@ -17,7 +17,6 @@
 #pragma once
 
 #include "syntax.h"
-#include "uniio.h"
 #include "workspace.h"
 
 


### PR DESCRIPTION
Реализована работа со структурами, поля которых имеют простой тип char, int или double. Также реализована работа с указателями на такие структуры. Подтянуты изменения из ветки parser главного репозитория, откорректирован кодогенератор исходя из этих изменений.