### PR TITLE
[#269] C++ compilation improvements

### DIFF
--- a/libs/compiler/builder.c
+++ b/libs/compiler/builder.c
@@ -28,7 +28,7 @@
  *	@param	loc			Error location
  *	@param	num			Error code
  */
-static void semantic_error(builder *const bldr, const location loc, error_t num, ...)
+static void semantic_error(builder *const bldr, const location loc, err_t num, ...)
 {
 	va_list args;
 	va_start(args, num);

--- a/libs/compiler/codegen.c
+++ b/libs/compiler/codegen.c
@@ -262,7 +262,7 @@ static void enc_clear(encoder *const enc)
  *	@param	enc			Encoder
  *	@param	num			Error code
  */
-static void encoder_error(encoder *const enc, const location loc, error_t num, ...)
+static void encoder_error(encoder *const enc, const location loc, err_t num, ...)
 {
 	va_list args;
 	va_start(args, num);

--- a/libs/compiler/codegen.c
+++ b/libs/compiler/codegen.c
@@ -824,8 +824,8 @@ static void emit_increment_expression(encoder *const enc, const node *const nd)
 	const node operand = expression_unary_get_operand(nd);
 	const lvalue value = emit_lvalue(enc, &operand);
 
-	const unary_t operator = expression_unary_get_operator(nd);
-	instruction_t instruction = unary_to_instruction(operator);
+	const unary_t op = expression_unary_get_operator(nd);
+	instruction_t instruction = unary_to_instruction(op);
 
 	if (value.kind == ADDRESS)
 	{
@@ -856,9 +856,9 @@ static void emit_increment_expression(encoder *const enc, const node *const nd)
 static void emit_unary_expression(encoder *const enc, const node *const nd)
 {
 	const item_t type = expression_get_type(nd);
-	const unary_t operator = expression_unary_get_operator(nd);
+	const unary_t op = expression_unary_get_operator(nd);
 	const node operand = expression_unary_get_operand(nd);
-	switch (operator)
+	switch (op)
 	{
 		case UN_POSTINC:
 		case UN_POSTDEC:
@@ -926,12 +926,12 @@ static void emit_integral_expression(encoder *const enc, const node *const nd)
 	emit_expression(enc, &LHS);
 
 	size_t addr = SIZE_MAX;
-	const binary_t operator = expression_binary_get_operator(nd);
-	const bool is_logical = operator == BIN_LOG_AND || operator == BIN_LOG_OR;
+	const binary_t op = expression_binary_get_operator(nd);
+	const bool is_logical = op == BIN_LOG_AND || op == BIN_LOG_OR;
 	if (is_logical)
 	{
 		mem_add(enc, IC_DUPLICATE);
-		mem_add(enc, operator == BIN_LOG_AND ? IC_BE0 : IC_BNE0);
+		mem_add(enc, op == BIN_LOG_AND ? IC_BE0 : IC_BNE0);
 		addr = mem_reserve(enc);
 	}
 
@@ -943,7 +943,7 @@ static void emit_integral_expression(encoder *const enc, const node *const nd)
 		mem_set(enc, addr, (item_t)mem_size(enc) + 1);
 	}
 
-	const instruction_t instruction = binary_to_instruction(operator);
+	const instruction_t instruction = binary_to_instruction(op);
 	if (type_is_floating(expression_get_type(&LHS)))
 	{
 		mem_add(enc, instruction_to_floating_ver(instruction));
@@ -1034,8 +1034,8 @@ static void emit_assignment_expression(encoder *const enc, const node *const nd)
 	}
 	else // Скалярное присваивание
 	{
-		const binary_t operator = expression_assignment_get_operator(nd);
-		instruction_t instruction = binary_to_instruction(operator);
+		const binary_t op = expression_assignment_get_operator(nd);
+		instruction_t instruction = binary_to_instruction(op);
 		if (value.kind == ADDRESS)
 		{
 			instruction = instruction_to_address_ver(instruction);

--- a/libs/compiler/errors.c
+++ b/libs/compiler/errors.c
@@ -32,7 +32,7 @@
 #define MAX_LINE_SIZE MAX_TAG_SIZE * 4
 
 #include <stdlib.h>
-static void get_error(const error_t num, char *const msg, va_list args)
+static void get_error(const err_t num, char *const msg, va_list args)
 {
 	switch (num)
 	{
@@ -453,7 +453,7 @@ static void output(const universal_io *const io, const char *const msg, const lo
  */
 
 
-void error(const universal_io *const io, error_t num, ...)
+void error(const universal_io *const io, err_t num, ...)
 {
 	va_list args;
 	va_start(args, num);
@@ -474,7 +474,7 @@ void warning(const universal_io *const io, warning_t num, ...)
 }
 
 
-void verror(const universal_io *const io, const error_t num, va_list args)
+void verror(const universal_io *const io, const err_t num, va_list args)
 {
 	char msg[MAX_MSG_SIZE];
 	get_error(num, msg, args);
@@ -489,7 +489,7 @@ void vwarning(const universal_io *const io, const warning_t num, va_list args)
 }
 
 
-void system_error(error_t num, ...)
+void system_error(err_t num, ...)
 {
 	va_list args;
 	va_start(args, num);

--- a/libs/compiler/errors.h
+++ b/libs/compiler/errors.h
@@ -146,7 +146,7 @@ typedef enum ERROR
 	// Codegen errors
 	tables_cannot_be_compressed,
 	wrong_init_in_actparam,
-} error_t;
+} err_t;
 
 /** Warnings codes */
 typedef enum WARNING
@@ -162,7 +162,7 @@ typedef enum WARNING
  *	@param	io			Universal io
  *	@param	num			Error number
  */
-void error(const universal_io *const io, error_t num, ...);
+void error(const universal_io *const io, err_t num, ...);
 
 /**
  *	Emit a warning for some problem
@@ -180,7 +180,7 @@ void warning(const universal_io *const io, warning_t num, ...);
  *	@param	num			Error number
  *	@param	args		Variable list
  */
-void verror(const universal_io *const io, const error_t num, va_list args);
+void verror(const universal_io *const io, const err_t num, va_list args);
 
 /**
  *	Emit a warning (embedded version)
@@ -197,7 +197,7 @@ void vwarning(const universal_io *const io, const warning_t num, va_list args);
  *
  *	@param	num			Error number
  */
-void system_error(error_t num, ...);
+void system_error(err_t num, ...);
 
 /**
  *	Emit a warning by number

--- a/libs/compiler/instructions.c
+++ b/libs/compiler/instructions.c
@@ -73,9 +73,9 @@ instruction_t builtin_to_instruction(const builtin_t func)
 	}
 }
 
-instruction_t unary_to_instruction(const unary_t operator)
+instruction_t unary_to_instruction(const unary_t op)
 {
-	switch (operator)
+	switch (op)
 	{
 		case UN_POSTINC:				return IC_POST_INC;
 		case UN_POSTDEC:				return IC_POST_DEC;
@@ -93,9 +93,9 @@ instruction_t unary_to_instruction(const unary_t operator)
 	}
 }
 
-instruction_t binary_to_instruction(const binary_t operator)
+instruction_t binary_to_instruction(const binary_t op)
 {
-	switch (operator)
+	switch (op)
 	{
 		case BIN_MUL:					return IC_MUL;
 		case BIN_DIV:					return IC_DIV;

--- a/libs/compiler/instructions.h
+++ b/libs/compiler/instructions.h
@@ -277,7 +277,7 @@ instruction_t builtin_to_instruction(const builtin_t func);
  *
  *	@return	Instruction
  */
-instruction_t unary_to_instruction(const unary_t operator);
+instruction_t unary_to_instruction(const unary_t op);
 
 /**
  *	Convert binary operator to corresponding instruction
@@ -286,7 +286,7 @@ instruction_t unary_to_instruction(const unary_t operator);
  *
  *	@return	Instruction
  */
-instruction_t binary_to_instruction(const binary_t operator);
+instruction_t binary_to_instruction(const binary_t op);
 
 
 /**

--- a/libs/compiler/instructions.h
+++ b/libs/compiler/instructions.h
@@ -273,7 +273,7 @@ instruction_t builtin_to_instruction(const builtin_t func);
 /**
  *	Convert unary operator to corresponding instruction
  *
- *	@param	operator		Unary operator
+ *	@param	op 				Unary operator
  *
  *	@return	Instruction
  */

--- a/libs/compiler/instructions.h
+++ b/libs/compiler/instructions.h
@@ -273,7 +273,7 @@ instruction_t builtin_to_instruction(const builtin_t func);
 /**
  *	Convert unary operator to corresponding instruction
  *
- *	@param	op 				Unary operator
+ *	@param	op				Unary operator
  *
  *	@return	Instruction
  */
@@ -282,7 +282,7 @@ instruction_t unary_to_instruction(const unary_t op);
 /**
  *	Convert binary operator to corresponding instruction
  *
- *	@param	operator		Binary operator
+ *	@param	op				Binary operator
  *
  *	@return	Instruction
  */

--- a/libs/compiler/lexer.c
+++ b/libs/compiler/lexer.c
@@ -26,7 +26,7 @@
  *	@param	lxr			Lexer
  *	@param	num			Error code
  */
-static void lexer_error(lexer *const lxr, error_t num, ...)
+static void lexer_error(lexer *const lxr, err_t num, ...)
 {
 	const size_t position = in_get_position(lxr->sx->io);
 	const location loc = { position, position + 1 };

--- a/libs/compiler/operations.c
+++ b/libs/compiler/operations.c
@@ -145,9 +145,9 @@ precedence_t get_operator_precedence(const token_t token)
 	}
 }
 
-bool operation_is_assignment(const binary_t operator)
+bool operation_is_assignment(const binary_t op)
 {
-	switch (operator)
+	switch (op)
 	{
 		case BIN_ASSIGN:
 		case BIN_ADD_ASSIGN:

--- a/libs/compiler/operations.h
+++ b/libs/compiler/operations.h
@@ -252,7 +252,7 @@ precedence_t get_operator_precedence(const token_t token);
  *
  *	@return	@c 1 on true, @c 0 on false
  */
-bool operation_is_assignment(const binary_t operator);
+bool operation_is_assignment(const binary_t op);
 
 #ifdef __cplusplus
 } /* extern "C" */

--- a/libs/compiler/operations.h
+++ b/libs/compiler/operations.h
@@ -248,7 +248,7 @@ precedence_t get_operator_precedence(const token_t token);
 /**
  *	Check if operator is assignment
  *
- *	@param	operator	Operator
+ *	@param	op			Operator
  *
  *	@return	@c 1 on true, @c 0 on false
  */

--- a/libs/compiler/parser.c
+++ b/libs/compiler/parser.c
@@ -106,7 +106,7 @@ static inline void parser_clear(parser *const prs)
  *	@param	prs			Parser
  *	@param	num			Error code
  */
-static void parser_error(parser *const prs, error_t num, ...)
+static void parser_error(parser *const prs, err_t num, ...)
 {
 	const location loc = token_get_location(&prs->tk);
 
@@ -171,7 +171,7 @@ static bool try_consume_token(parser *const prs, const token_t expected)
  *	@param	expected	Expected token kind
  *	@param	err			Error to emit
  */
-static void expect_and_consume(parser *const prs, const token_t expected, const error_t err)
+static void expect_and_consume(parser *const prs, const token_t expected, const err_t err)
 {
 	if (try_consume_token(prs, expected))
 	{

--- a/libs/compiler/reporter.c
+++ b/libs/compiler/reporter.c
@@ -66,7 +66,7 @@ size_t reporter_get_errors_number(reporter *const rprt)
 	return rprt->errors;
 }
 
-void report_error(reporter *const rprt, universal_io *const io, const location loc, const error_t num, va_list args)
+void report_error(reporter *const rprt, universal_io *const io, const location loc, const err_t num, va_list args)
 {
 	if (rprt->is_recovery_disabled && rprt->errors != 0)
 	{

--- a/libs/compiler/reporter.h
+++ b/libs/compiler/reporter.h
@@ -60,7 +60,7 @@ size_t reporter_get_errors_number(reporter *const rprt);
  *	@param	num			Error code
  *	@param	args		Variable list
  */
-void report_error(reporter *const rprt, universal_io *const io, const location loc, const error_t num, va_list args);
+void report_error(reporter *const rprt, universal_io *const io, const location loc, const err_t num, va_list args);
 
 /**
  *	Report a warning

--- a/libs/compiler/token.c
+++ b/libs/compiler/token.c
@@ -16,27 +16,101 @@
 
 #include "token.h"
 
+/*
+ *   __     __   __     ______   ______     ______     ______   ______     ______     ______
+ *  /\ \   /\ "-.\ \   /\__  _\ /\  ___\   /\  == \   /\  ___\ /\  __ \   /\  ___\   /\  ___\
+ *  \ \ \  \ \ \-.  \  \/_/\ \/ \ \  __\   \ \  __<   \ \  __\ \ \  __ \  \ \ \____  \ \  __\
+ *   \ \_\  \ \_\\"\_\    \ \_\  \ \_____\  \ \_\ \_\  \ \_\    \ \_\ \_\  \ \_____\  \ \_____\
+ *    \/_/   \/_/ \/_/     \/_/   \/_____/   \/_/ /_/   \/_/     \/_/\/_/   \/_____/   \/_____/
+ */
 
-extern location token_get_location(const token *const tk);
-extern token_t token_get_kind(const token *const tk);
-extern bool token_is(const token *const tk, const token_t kind);
-extern bool token_is_not(const token *const tk, const token_t kind);
 
-extern token token_identifier(const location loc, const size_t name);
-extern size_t token_get_ident_name(const token *const tk);
+location token_get_location(const token *const tk)
+{
+	return tk->loc;
+}
 
-extern token token_char_literal(const location loc, const char32_t value);
-char32_t token_get_char_value(const token *const tk);
+token_t token_get_kind(const token *const tk)
+{
+	return tk->kind;
+}
 
-extern token token_int_literal(const location loc, const uint64_t value);
-extern uint64_t token_get_int_value(const token *const tk);
+bool token_is(const token *const tk, const token_t kind)
+{
+	return tk->kind == kind;
+}
 
-extern token token_float_literal(const location loc, const double value);
-extern double token_get_float_value(const token *const tk);
+bool token_is_not(const token *const tk, const token_t kind)
+{
+	return tk->kind != kind;
+}
 
-extern token token_string_literal(const location loc, const size_t string_num);
-extern size_t token_get_string_num(const token *const tk);
+token token_identifier(const location loc, const size_t name)
+{
+	return (token){ .loc = loc, .kind = TK_IDENTIFIER, .data.ident_repr = name };
+}
 
-extern token token_eof();
-extern token token_keyword(const location loc, const token_t kind);
-extern token token_punctuator(const location loc, const token_t kind);
+size_t token_get_ident_name(const token *const tk)
+{
+	assert(tk->kind == TK_IDENTIFIER);
+	return tk->data.ident_repr;
+}
+
+token token_char_literal(const location loc, const char32_t value)
+{
+	return (token){ .loc = loc, .kind = TK_CHAR_LITERAL, .data.char_value = value };
+}
+
+char32_t token_get_char_value(const token *const tk)
+{
+	assert(tk->kind == TK_CHAR_LITERAL);
+	return tk->data.char_value;
+}
+
+token token_int_literal(const location loc, const uint64_t value)
+{
+	return (token){ .loc = loc, .kind = TK_INT_LITERAL, .data.int_value = value };
+}
+
+uint64_t token_get_int_value(const token *const tk)
+{
+	assert(tk->kind == TK_INT_LITERAL);
+	return tk->data.int_value;
+}
+
+token token_float_literal(const location loc, const double value)
+{
+	return (token){ .loc = loc, .kind = TK_FLOAT_LITERAL, .data.float_value = value };
+}
+
+double token_get_float_value(const token *const tk)
+{
+	assert(tk->kind == TK_FLOAT_LITERAL);
+	return tk->data.float_value;
+}
+
+token token_string_literal(const location loc, const size_t string_num)
+{
+	return (token){ .loc = loc, .kind = TK_STRING_LITERAL, .data.string_num = string_num };
+}
+
+size_t token_get_string_num(const token *const tk)
+{
+	assert(tk->kind == TK_STRING_LITERAL);
+	return tk->data.string_num;
+}
+
+token token_eof()
+{
+	return (token){ .loc = { SIZE_MAX, SIZE_MAX }, .kind = TK_EOF };
+}
+
+token token_keyword(const location loc, const token_t kind)
+{
+	return (token){ .loc = loc, .kind = kind };
+}
+
+token token_punctuator(const location loc, const token_t kind)
+{
+	return (token){ .loc = loc, .kind = kind };
+}

--- a/libs/compiler/token.h
+++ b/libs/compiler/token.h
@@ -147,11 +147,7 @@ typedef struct token
  *
  *	@return	Token location
  */
-inline location token_get_location(const token *const tk)
-{
-	return tk->loc;
-}
-
+location token_get_location(const token *const tk);
 /**
  *	Get token kind
  *
@@ -159,23 +155,13 @@ inline location token_get_location(const token *const tk)
  *
  *	@return	Token kind
  */
-inline token_t token_get_kind(const token *const tk)
-{
-	return tk->kind;
-}
+token_t token_get_kind(const token *const tk);
 
 /**	Check if token is of @c kind kind */
-inline bool token_is(const token *const tk, const token_t kind)
-{
-	return tk->kind == kind;
-}
+bool token_is(const token *const tk, const token_t kind);
 
 /**	Check if token is not of @c kind kind */
-inline bool token_is_not(const token *const tk, const token_t kind)
-{
-	return tk->kind != kind;
-}
-
+bool token_is_not(const token *const tk, const token_t kind);
 
 /**
  *	Create identifier token
@@ -185,11 +171,7 @@ inline bool token_is_not(const token *const tk, const token_t kind)
  *
  *	@return	Identifier token
  */
-inline token token_identifier(const location loc, const size_t name)
-{
-	return (token){ .loc = loc, .kind = TK_IDENTIFIER, .data.ident_repr = name };
-}
-
+token token_identifier(const location loc, const size_t name);
 /**
  *	Get identifier name from identifier token
  *
@@ -197,12 +179,7 @@ inline token token_identifier(const location loc, const size_t name)
  *
  *	@return	Identifier name
  */
-inline size_t token_get_ident_name(const token *const tk)
-{
-	assert(tk->kind == TK_IDENTIFIER);
-	return tk->data.ident_repr;
-}
-
+size_t token_get_ident_name(const token *const tk);
 
 /**
  *	Create character literal token
@@ -212,10 +189,7 @@ inline size_t token_get_ident_name(const token *const tk)
  *
  *	@return	Character literal token
  */
-inline token token_char_literal(const location loc, const char32_t value)
-{
-	return (token){ .loc = loc, .kind = TK_CHAR_LITERAL, .data.char_value = value };
-}
+token token_char_literal(const location loc, const char32_t value);
 
 /**
  *	Get value from character literal token
@@ -224,11 +198,7 @@ inline token token_char_literal(const location loc, const char32_t value)
  *
  *	@return	Value
  */
-inline char32_t token_get_char_value(const token *const tk)
-{
-	assert(tk->kind == TK_CHAR_LITERAL);
-	return tk->data.char_value;
-}
+char32_t token_get_char_value(const token *const tk);
 
 
 /**
@@ -239,10 +209,7 @@ inline char32_t token_get_char_value(const token *const tk)
  *
  *	@return	Integer literal token
  */
-inline token token_int_literal(const location loc, const uint64_t value)
-{
-	return (token){ .loc = loc, .kind = TK_INT_LITERAL, .data.int_value = value };
-}
+token token_int_literal(const location loc, const uint64_t value);
 
 /**
  *	Get value from integer literal token
@@ -251,12 +218,7 @@ inline token token_int_literal(const location loc, const uint64_t value)
  *
  *	@return	Value
  */
-inline uint64_t token_get_int_value(const token *const tk)
-{
-	assert(tk->kind == TK_INT_LITERAL);
-	return tk->data.int_value;
-}
-
+uint64_t token_get_int_value(const token *const tk);
 
 /**
  *	Create floating literal token
@@ -266,10 +228,7 @@ inline uint64_t token_get_int_value(const token *const tk)
  *
  *	@return	Floating literal token
  */
-inline token token_float_literal(const location loc, const double value)
-{
-	return (token){ .loc = loc, .kind = TK_FLOAT_LITERAL, .data.float_value = value };
-}
+token token_float_literal(const location loc, const double value);
 
 /**
  *	Get value from floating literal token
@@ -278,12 +237,7 @@ inline token token_float_literal(const location loc, const double value)
  *
  *	@return	Value
  */
-inline double token_get_float_value(const token *const tk)
-{
-	assert(tk->kind == TK_FLOAT_LITERAL);
-	return tk->data.float_value;
-}
-
+double token_get_float_value(const token *const tk);
 
 /**
  *	Create string literal token
@@ -293,10 +247,7 @@ inline double token_get_float_value(const token *const tk)
  *
  *	@return	String literal token
  */
-inline token token_string_literal(const location loc, const size_t string_num)
-{
-	return (token){ .loc = loc, .kind = TK_STRING_LITERAL, .data.string_num = string_num };
-}
+token token_string_literal(const location loc, const size_t string_num);
 
 /**
  *	Get string index from string literal token
@@ -305,22 +256,14 @@ inline token token_string_literal(const location loc, const size_t string_num)
  *
  *	@return	Value
  */
-inline size_t token_get_string_num(const token *const tk)
-{
-	assert(tk->kind == TK_STRING_LITERAL);
-	return tk->data.string_num;
-}
-
+size_t token_get_string_num(const token *const tk);
 
 /**
  *	Create end-of-file token
  *
  *	@return	EOF token
  */
-inline token token_eof()
-{
-	return (token){ .loc = { SIZE_MAX, SIZE_MAX }, .kind = TK_EOF };
-}
+token token_eof();
 
 /**
  *	Create keyword token
@@ -330,10 +273,7 @@ inline token token_eof()
  *
  *	@return	Keyword token
  */
-inline token token_keyword(const location loc, const token_t kind)
-{
-	return (token){ .loc = loc, .kind = kind };
-}
+token token_keyword(const location loc, const token_t kind);
 
 /**
  *	Create punctuator token
@@ -343,10 +283,7 @@ inline token token_keyword(const location loc, const token_t kind)
  *
  *	@return	Punctuator token
  */
-inline token token_punctuator(const location loc, const token_t kind)
-{
-	return (token){ .loc = loc, .kind = kind };
-}
+token token_punctuator(const location loc, const token_t kind);
 
 #ifdef __cplusplus
 } /* extern "C" */

--- a/libs/compiler/writer.c
+++ b/libs/compiler/writer.c
@@ -102,7 +102,7 @@ static void write_type(writer *const wrt, const item_t type)
  *	Write unary operator spelling
  *
  *	@param	wrt			Writer
- *	@param	operator	Operator
+ *	@param	op			Operator
  */
 static void write_unary_operator(writer *const wrt, const unary_t op)
 {
@@ -148,7 +148,7 @@ static void write_unary_operator(writer *const wrt, const unary_t op)
  *	Write binary operator spelling
  *
  *	@param	wrt			Writer
- *	@param	operator	Operator
+ *	@param	op			Operator
  */
 static void write_binary_operator(writer *const wrt, const binary_t op)
 {

--- a/libs/compiler/writer.c
+++ b/libs/compiler/writer.c
@@ -104,9 +104,9 @@ static void write_type(writer *const wrt, const item_t type)
  *	@param	wrt			Writer
  *	@param	operator	Operator
  */
-static void write_unary_operator(writer *const wrt, const unary_t operator)
+static void write_unary_operator(writer *const wrt, const unary_t op)
 {
-	switch (operator)
+	switch (op)
 	{
 		case UN_POSTINC:
 			write(wrt, "'postfix ++'");
@@ -150,9 +150,9 @@ static void write_unary_operator(writer *const wrt, const unary_t operator)
  *	@param	wrt			Writer
  *	@param	operator	Operator
  */
-static void write_binary_operator(writer *const wrt, const binary_t operator)
+static void write_binary_operator(writer *const wrt, const binary_t op)
 {
-	switch (operator)
+	switch (op)
 	{
 		case BIN_MUL:
 			write(wrt, "'*'");


### PR DESCRIPTION
This patch series addresses several problems when interoperating with C++.
1. error_t clashes with std::error_t.
2. Avoid GNU extensions (designated initializers) in headers.
3. Variable name "operator" clashes with C++'s "operator" keyword.