### PR TITLE
[#271] Preserve structure names

### DIFF
--- a/libs/compiler/AST.c
+++ b/libs/compiler/AST.c
@@ -897,7 +897,7 @@ declaration_t declaration_get_class(const node *const nd)
 item_t declaration_type_get_type(const node *const nd)
 {
 	assert(node_get_type(nd) == OP_DECL_TYPE);
-	return (size_t)node_get_arg(nd, 0);
+	return node_get_arg(nd, 0);
 }
 
 size_t declaration_type_get_id(const node *const nd)

--- a/libs/compiler/AST.c
+++ b/libs/compiler/AST.c
@@ -894,6 +894,17 @@ declaration_t declaration_get_class(const node *const nd)
 	}
 }
 
+item_t declaration_type_get_type(const node *const nd)
+{
+	assert(node_get_type(nd) == OP_DECL_TYPE);
+	return (size_t)node_get_arg(nd, 0);
+}
+
+size_t declaration_type_get_id(const node *const nd)
+{
+	assert(node_get_type(nd) == OP_DECL_TYPE);
+	return (size_t)node_get_arg(nd, 1);
+}
 
 size_t declaration_variable_get_id(const node *const nd)
 {

--- a/libs/compiler/AST.h
+++ b/libs/compiler/AST.h
@@ -1020,6 +1020,24 @@ declaration_t declaration_get_class(const node *const nd);
 
 
 /**
+ *  Get type that declaration defines
+ *
+ *  @param  nd              Type declaration
+ *
+ *  @return Declaration type
+ */
+item_t declaration_type_get_type(const node *const nd);
+
+/**
+ *  Get type id in type declaration
+ *
+ *  @param  nd              Type declaration
+ *
+ *  @return Id
+ */
+size_t declaration_type_get_id(const node *const nd);
+
+/**
  *	Get variable id in variable declaration
  *
  *	@param	nd				Variable declaration

--- a/libs/compiler/parser.c
+++ b/libs/compiler/parser.c
@@ -929,7 +929,7 @@ static item_t parse_struct_or_union_specifier(parser *const prs, node *const par
 
 				prs->was_type_def = true;
 
-				return ident_get_type(prs->sx, id);
+				return ident_get_type(prs->sx, (size_t)id);
 			}
 			else // if (parser->next_token != l_brace)
 			{

--- a/libs/compiler/parser.c
+++ b/libs/compiler/parser.c
@@ -51,7 +51,7 @@ typedef struct parser
 
 
 static item_t parse_struct_or_union_specifier(parser *const prs, node *const parent);
-static item_t parse_struct_declaration_list(parser *const prs, node *const parent);
+static item_t parse_struct_declaration_list(parser *const prs, node *const parent, const size_t repr);
 static item_t parse_enum_specifier(parser *const prs, node *const parent);
 static location consume_token(parser *const prs);
 static node parse_expression(parser *const prs);
@@ -910,7 +910,7 @@ static item_t parse_struct_or_union_specifier(parser *const prs, node *const par
 	switch (token_get_kind(&prs->tk))
 	{
 		case TK_L_BRACE:
-			return parse_struct_declaration_list(prs, parent);
+			return parse_struct_declaration_list(prs, parent, 0);
 
 		case TK_IDENTIFIER:
 		{
@@ -919,8 +919,14 @@ static item_t parse_struct_or_union_specifier(parser *const prs, node *const par
 
 			if (token_is(&prs->tk, TK_L_BRACE))
 			{
-				const item_t type = parse_struct_declaration_list(prs, parent);
-				const size_t id = to_identab(prs, repr, 1000, type);
+				const item_t type = parse_struct_declaration_list(prs, parent,
+					repr);
+				if (type == ITEM_MAX)
+				{
+					return TYPE_UNDEFINED;
+				}
+				const item_t id = repr_get_reference(prs->sx, repr);
+
 				prs->was_type_def = true;
 
 				return ident_get_type(prs->sx, id);
@@ -1022,7 +1028,7 @@ static item_t parse_array_definition(parser *const prs, node *const parent, item
  *
  *	@return	Index of types table, @c type_undefined on failure
  */
-static item_t parse_struct_declaration_list(parser *const prs, node *const parent)
+static item_t parse_struct_declaration_list(parser *const prs, node *const parent, const size_t repr)
 {
 	consume_token(prs);
 	if (try_consume_token(prs, TK_R_BRACE))
@@ -1037,7 +1043,10 @@ static item_t parse_struct_declaration_list(parser *const prs, node *const paren
 	size_t displ = 0;
 
 	node nd;
-	bool was_array = false;
+
+	nd = node_add_child(parent, OP_DECL_TYPE);
+	node_add_arg(&nd, 0);
+	node_add_arg(&nd, 0);
 
 	do
 	{
@@ -1061,13 +1070,6 @@ static item_t parse_struct_declaration_list(parser *const prs, node *const paren
 
 			if (token_is(&prs->tk, TK_L_SQUARE))
 			{
-				if (!was_array)
-				{
-					nd = node_add_child(parent, OP_DECL_TYPE);
-					node_add_arg(&nd, 0);
-					was_array = true;
-				}
-
 				node decl = node_add_child(&nd, OP_DECL_VAR);
 				node_add_arg(&decl, 0);
 				node_add_arg(&decl, 0);
@@ -1097,9 +1099,12 @@ static item_t parse_struct_declaration_list(parser *const prs, node *const paren
 	local_modetab[2] = (item_t)fields * 2;
 
 	const item_t result = type_add(prs->sx, local_modetab, local_md);
-	if (was_array)
+	node_set_arg(&nd, 0, result);
+
+	if (repr != 0)
 	{
-		node_set_arg(&nd, 0, result);
+		const size_t id = to_identab(prs, repr, 1000, result);
+		node_set_arg(&nd, 1, id);
 	}
 
 	return result;

--- a/libs/compiler/parser.c
+++ b/libs/compiler/parser.c
@@ -1070,7 +1070,7 @@ static item_t parse_struct_declaration_list(parser *const prs, node *const paren
 
 		if (token_is(&prs->tk, TK_IDENTIFIER))
 		{
-			const size_t repr = token_get_ident_name(&prs->tk);
+			const size_t inner_repr = token_get_ident_name(&prs->tk);
 			consume_token(prs);
 
 			if (token_is(&prs->tk, TK_L_SQUARE))
@@ -1086,7 +1086,7 @@ static item_t parse_struct_declaration_list(parser *const prs, node *const paren
 			}
 
 			local_modetab[local_md++] = type;
-			local_modetab[local_md++] = (item_t)repr;
+			local_modetab[local_md++] = (item_t)inner_repr;
 			fields++;
 			displ += type_size(prs->sx, type);
 		}

--- a/libs/compiler/parser.c
+++ b/libs/compiler/parser.c
@@ -1024,6 +1024,7 @@ static item_t parse_array_definition(parser *const prs, node *const parent, item
  *
  *	@param	prs			Parser structure
  *	@param	parent		Parent node in AST
+ *	@param	repr		Structure identifier index in representations table
  *
  *	@return	Index of types table, @c type_undefined on failure
  */

--- a/libs/compiler/parser.c
+++ b/libs/compiler/parser.c
@@ -919,8 +919,7 @@ static item_t parse_struct_or_union_specifier(parser *const prs, node *const par
 
 			if (token_is(&prs->tk, TK_L_BRACE))
 			{
-				const item_t type = parse_struct_declaration_list(prs, parent,
-					repr);
+				const item_t type = parse_struct_declaration_list(prs, parent, repr);
 				if (type == ITEM_MAX)
 				{
 					return TYPE_UNDEFINED;

--- a/libs/compiler/writer.c
+++ b/libs/compiler/writer.c
@@ -646,14 +646,26 @@ static void write_variable_declaration(writer *const wrt, const node *const nd)
  */
 static void write_type_declaration(writer *const wrt, const node *const nd)
 {
+	const char *spelling = NULL;
+	item_t      type = ITEM_MAX;
+
 	write_line(wrt, "DECL_TYPE");
 
 	const size_t ident = declaration_type_get_id(nd);
-	const item_t type = ident_get_type(wrt->sx, ident);
-	const char *const spelling = ident_get_spelling(wrt->sx, ident);
+	if (ident != SIZE_MAX)
+	{
+		type = ident_get_type(wrt->sx, ident);
+		spelling = ident_get_spelling(wrt->sx, ident);
+	}
+
+	if (spelling == NULL)
+	{
+		spelling = "<unnamed>";
+	}
 
 	uni_printf(wrt->io, " declaring type named \'%s\' with id %zu: '", spelling, ident);
-	write_type(wrt, type);
+	if (type != ITEM_MAX)
+		write_type(wrt, type);
 	write(wrt, "'\n");
 }
 

--- a/libs/compiler/writer.c
+++ b/libs/compiler/writer.c
@@ -647,7 +647,7 @@ static void write_variable_declaration(writer *const wrt, const node *const nd)
 static void write_type_declaration(writer *const wrt, const node *const nd)
 {
 	const char *spelling = NULL;
-	item_t      type = ITEM_MAX;
+	item_t type = ITEM_MAX;
 
 	write_line(wrt, "DECL_TYPE");
 
@@ -665,7 +665,9 @@ static void write_type_declaration(writer *const wrt, const node *const nd)
 
 	uni_printf(wrt->io, " declaring type named \'%s\' with id %zu: '", spelling, ident);
 	if (type != ITEM_MAX)
+	{
 		write_type(wrt, type);
+	}
 	write(wrt, "'\n");
 }
 

--- a/libs/compiler/writer.c
+++ b/libs/compiler/writer.c
@@ -646,8 +646,15 @@ static void write_variable_declaration(writer *const wrt, const node *const nd)
  */
 static void write_type_declaration(writer *const wrt, const node *const nd)
 {
-	write_line(wrt, "DECL_TYPE\n");
-	(void)nd;
+	write_line(wrt, "DECL_TYPE");
+
+	const size_t ident = declaration_type_get_id(nd);
+	const item_t type = ident_get_type(wrt->sx, ident);
+	const char *const spelling = ident_get_spelling(wrt->sx, ident);
+
+	uni_printf(wrt->io, " declaring type named \'%s\' with id %zu: '", spelling, ident);
+	write_type(wrt, type);
+	write(wrt, "'\n");
 }
 
 /**


### PR DESCRIPTION
 - Structure names are saved as argument [1] of type declaration nodes.
 - Type declarations are created for all structures.