### PR TITLE
Fix getting type of return statement in mipsgen

### DIFF
--- a/libs/compiler/mipsgen.c
+++ b/libs/compiler/mipsgen.c
@@ -3656,8 +3656,7 @@ static void emit_return_statement(encoder *const enc, const node *const nd)
 		const node expression = statement_return_get_expression(nd);
 		const rvalue value = emit_expression(enc, &expression);
 
-		const item_t type = expression_get_type(nd);
-		const lvalue return_lval = { .kind = LVALUE_KIND_REGISTER, .loc.reg_num = R_V0, .type = type };
+		const lvalue return_lval = { .kind = LVALUE_KIND_REGISTER, .loc.reg_num = R_V0, .type = value.type };
 
 		emit_store_of_rvalue(enc, &return_lval, &value);
 		free_rvalue(enc, &value);


### PR DESCRIPTION
Because nd is not an expression, but a statement, usage of `expression_get_type(nd)` is unacceptable and produces unexpected results, so program crashes on `assert(value->type == target->type)` in `emit_store_of_rvalue`.
Since check if return statement correct happens during tree construction, we can just set `return_lval.type = value.type`