### PR TITLE
Fix function arguments behaviour in mipsgen

### DIFF
--- a/libs/compiler/mipsgen.c
+++ b/libs/compiler/mipsgen.c
@@ -1138,38 +1138,6 @@ static lvalue displacements_add(encoder *const enc, const size_t identifier
 }
 
 /**
- *	Add new function argument to displacements table
- *
- *	@param	enc					Encoder
- *	@param	identifier			Identifier for adding to the table
- *	@param	location			Location of identifier - register, or displacement on stack
- *	@param	is_register			@c true, if identifier is register variable, and @c false otherwise
- *
- *	@return	Identifier lvalue
- */
-static lvalue displacements_add_function_argument(encoder *const enc, const size_t identifier
-	, const item_t location, const bool is_register)
-{
-	const size_t displacement = enc->scope_displ;
-	const bool is_local = ident_is_local(enc->sx, identifier);
-	const mips_register_t base_reg = R_FP;
-	const item_t type = ident_get_type(enc->sx, identifier);
-
-	if (!is_local)	// Параметр функции не может быть глобальной переменной
-	{
-		// TODO: кидать соответствующую ошибку
-		system_error(node_unexpected);
-	}
-
-	const size_t index = hash_add(&enc->displacements, identifier, 3);
-	hash_set_by_index(&enc->displacements, index, 0, (is_register) ? 1 : 0);
-	hash_set_by_index(&enc->displacements, index, 1, location);
-	hash_set_by_index(&enc->displacements, index, 2, base_reg);
-
-	return (lvalue) { .kind = LVALUE_KIND_STACK, .base_reg = base_reg, .loc.displ = displacement, .type = type };
-}
-
-/**
  *	Return lvalue for the given identifier
  *
  *	@param	enc					Encoder
@@ -3204,7 +3172,7 @@ static void emit_function_definition(encoder *const enc, const node *const nd)
 				uni_printf(enc->sx->io, "\n");
 
 				// Вносим переменную в таблицу символов
-				displacements_add_function_argument(enc, id, curr_reg, true);
+				displacements_add(enc, id, curr_reg, true);
 			}
 			else
 			{
@@ -3222,7 +3190,7 @@ static void emit_function_definition(encoder *const enc, const node *const nd)
 				mips_register_to_io(enc->sx->io, curr_reg);
 				uni_printf(enc->sx->io, "\n");
 
-				displacements_add_function_argument(enc, id, curr_reg, true);
+				displacements_add(enc, id, curr_reg, true);
 			}
 			else
 			{

--- a/libs/compiler/mipsgen.c
+++ b/libs/compiler/mipsgen.c
@@ -3195,7 +3195,7 @@ static void emit_function_definition(encoder *const enc, const node *const nd)
 
 		if (!type_is_floating(ident_get_type(enc->sx, id)))
 		{
-			if (i < ARG_REG_AMOUNT)
+			if (gpr_count < ARG_REG_AMOUNT)
 			{
 				// Рассматриваем их как регистровые переменные
 				const mips_register_t curr_reg = R_A0 + gpr_count++;
@@ -3214,7 +3214,7 @@ static void emit_function_definition(encoder *const enc, const node *const nd)
 		}
 		else
 		{
-			if (i < ARG_REG_AMOUNT / 2)
+			if (fp_count < ARG_REG_AMOUNT / 2)
 			{
 				// Рассматриваем их как регистровые переменные
 				const mips_register_t curr_reg = R_FA0 + 2 * fp_count++;

--- a/libs/compiler/mipsgen.c
+++ b/libs/compiler/mipsgen.c
@@ -1124,14 +1124,14 @@ static lvalue displacements_add(encoder *const enc, const size_t identifier
 	hash_set_by_index(&enc->displacements, index, 1, location);
 	hash_set_by_index(&enc->displacements, index, 2, base_reg);
 
-	if (is_local)
+	if (!is_local)
+	{
+		enc->global_displ += mips_type_size(enc->sx, type);
+	}
+	else if (!is_register)
 	{
 		enc->scope_displ += mips_type_size(enc->sx, type);
 		enc->max_displ = max(enc->scope_displ, enc->max_displ);
-	}
-	else
-	{
-		enc->global_displ += mips_type_size(enc->sx, type);
 	}
 
 	return (lvalue) { .kind = LVALUE_KIND_STACK, .base_reg = base_reg, .loc.displ = displacement, .type = type };

--- a/libs/compiler/mipsgen.c
+++ b/libs/compiler/mipsgen.c
@@ -1138,6 +1138,38 @@ static lvalue displacements_add(encoder *const enc, const size_t identifier
 }
 
 /**
+ *	Add new function argument to displacements table
+ *
+ *	@param	enc					Encoder
+ *	@param	identifier			Identifier for adding to the table
+ *	@param	location			Location of identifier - register, or displacement on stack
+ *	@param	is_register			@c true, if identifier is register variable, and @c false otherwise
+ *
+ *	@return	Identifier lvalue
+ */
+static lvalue displacements_add_function_argument(encoder *const enc, const size_t identifier
+	, const item_t location, const bool is_register)
+{
+	const size_t displacement = enc->scope_displ;
+	const bool is_local = ident_is_local(enc->sx, identifier);
+	const mips_register_t base_reg = R_FP;
+	const item_t type = ident_get_type(enc->sx, identifier);
+
+	if (!is_local)	// Параметр функции не может быть глобальной переменной
+	{
+		// TODO: кидать соответствующую ошибку
+		system_error(node_unexpected);
+	}
+
+	const size_t index = hash_add(&enc->displacements, identifier, 3);
+	hash_set_by_index(&enc->displacements, index, 0, (is_register) ? 1 : 0);
+	hash_set_by_index(&enc->displacements, index, 1, location);
+	hash_set_by_index(&enc->displacements, index, 2, base_reg);
+
+	return (lvalue) { .kind = LVALUE_KIND_STACK, .base_reg = base_reg, .loc.displ = displacement, .type = type };
+}
+
+/**
  *	Return lvalue for the given identifier
  *
  *	@param	enc					Encoder
@@ -3172,7 +3204,7 @@ static void emit_function_definition(encoder *const enc, const node *const nd)
 				uni_printf(enc->sx->io, "\n");
 
 				// Вносим переменную в таблицу символов
-				displacements_add(enc, id, curr_reg, true);
+				displacements_add_function_argument(enc, id, curr_reg, true);
 			}
 			else
 			{
@@ -3190,7 +3222,7 @@ static void emit_function_definition(encoder *const enc, const node *const nd)
 				mips_register_to_io(enc->sx->io, curr_reg);
 				uni_printf(enc->sx->io, "\n");
 
-				displacements_add(enc, id, curr_reg, true);
+				displacements_add_function_argument(enc, id, curr_reg, true);
 			}
 			else
 			{

--- a/libs/compiler/mipsgen.c
+++ b/libs/compiler/mipsgen.c
@@ -3163,7 +3163,7 @@ static void emit_function_definition(encoder *const enc, const node *const nd)
 
 		if (!type_is_floating(ident_get_type(enc->sx, id)))
 		{
-			if (gpr_count < ARG_REG_AMOUNT)
+			if (i < ARG_REG_AMOUNT)
 			{
 				// Рассматриваем их как регистровые переменные
 				const mips_register_t curr_reg = R_A0 + gpr_count++;
@@ -3182,7 +3182,7 @@ static void emit_function_definition(encoder *const enc, const node *const nd)
 		}
 		else
 		{
-			if (fp_count < ARG_REG_AMOUNT / 2)
+			if (i < ARG_REG_AMOUNT / 2)
 			{
 				// Рассматриваем их как регистровые переменные
 				const mips_register_t curr_reg = R_FA0 + 2 * fp_count++;


### PR DESCRIPTION
If we just call `displacement_add` when adding function argument to displacements table, stack size for function will increase, which is unnecessary because arguments are in registers.
So i created separate function for adding function arguments to displacements table.
Also fixed check if argumeint is register