### PR TITLE
Fix data restoring after function call in mipsgen

### DIFF
--- a/libs/compiler/mipsgen.c
+++ b/libs/compiler/mipsgen.c
@@ -273,6 +273,18 @@ typedef struct lvalue
 	const item_t type;						/**< Value type */
 } lvalue;
 
+typedef struct mutable_lvalue
+{
+	lvalue_kind_t kind;						/**< Value kind */
+	mips_register_t base_reg;				/**< Base register */
+	union									/**< Value location */
+	{
+		item_t reg_num;						/**< Register where the value is stored */
+		item_t displ;						/**< Stack displacement where the value is stored */
+	} loc;
+	item_t type;							/**< Value type */
+} mutable_lvalue;
+
 
 /** Kinds of rvalue */
 typedef enum RVALUE_KIND
@@ -1093,6 +1105,16 @@ static void lvalue_to_io(encoder *const enc, const lvalue *const value)
 		mips_register_to_io(enc->sx->io, value->base_reg);
 		uni_printf(enc->sx->io, ")\n");
 	}
+}
+
+static lvalue mutable_lvalue_to_lvalue(const mutable_lvalue val) 
+{
+	return (lvalue) {.kind = val.kind, .base_reg = val.base_reg, .loc.displ = val.loc.displ, .type = val.type};
+}
+
+static mutable_lvalue lvalue_to_mutable_lvalue(const lvalue val) 
+{
+	return (mutable_lvalue) {.kind = val.kind, .base_reg = val.base_reg, .loc.displ = val.loc.displ, .type = val.type};
 }
 
 /**
@@ -2120,7 +2142,7 @@ static rvalue emit_call_expression(encoder *const enc, const node *const nd)
 		size_t f_arg_count = 0;
 		size_t arg_count = 0;
 		size_t displ_for_parameters = (params_amount - 1) * WORD_LENGTH;
-		const lvalue *prev_arg_displ[4 /* за $a0-$a3 */
+		mutable_lvalue prev_arg_displ[4 /* за $a0-$a3 */
 									+ 4 / 2 /* за $fa0, $fa2 (т.к. single precision)*/];
 
 		uni_printf(enc->sx->io, "\t# setting up $sp:\n");
@@ -2190,7 +2212,7 @@ static rvalue emit_call_expression(encoder *const enc, const node *const nd)
 					&arg_rvalue);
 
 				// Запоминаем, куда положили текущее значение, лежавшее в регистре-аргументе
-				prev_arg_displ[arg_reg_count++] = &tmp_arg_lvalue;
+				prev_arg_displ[arg_reg_count++] = lvalue_to_mutable_lvalue(tmp_arg_lvalue);
 			}
 
 			if (type_is_floating(arg_rvalue.type))
@@ -2216,10 +2238,11 @@ static rvalue emit_call_expression(encoder *const enc, const node *const nd)
 		{
 			uni_printf(enc->sx->io, "\n");
 
-			const rvalue tmp_rval = emit_load_of_lvalue(enc, prev_arg_displ[i + j]);
+			const lvalue tmp_lval = mutable_lvalue_to_lvalue(prev_arg_displ[i + j]);
+			const rvalue tmp_rval = emit_load_of_lvalue(enc, &tmp_lval);
 			emit_move_rvalue_to_register(
 				enc,
-				type_is_floating(prev_arg_displ[i + j]->type) ? (R_FA0 + 2 * j++) : (R_A0 + i++),
+				type_is_floating(tmp_lval.type) ? (R_FA0 + 2 * j++) : (R_A0 + i++),
 				&tmp_rval
 			);
 


### PR DESCRIPTION
Previously `prev_arg_displ` was an array of pointers, which was filled with pointer to the `tmp_arg_lvalue`, which is on stack, so instead of 6 different lvalue's, it contained only the last one, which broke data restoring after function call.