### PR TITLE
Add support for more than four function arguments in mipsgen

### DIFF
--- a/libs/compiler/mipsgen.c
+++ b/libs/compiler/mipsgen.c
@@ -1114,7 +1114,7 @@ static lvalue displacements_add(encoder *const enc, const size_t identifier)
 		enc->scope_displ += mips_type_size(enc->sx, type);
 		enc->max_displ = max(enc->scope_displ, enc->max_displ);
 	}
-	const item_t location = is_local ? -(item_t)enc->scope_displ : enc->global_displ;
+	const item_t location = is_local ? -(item_t)enc->scope_displ : (item_t)enc->global_displ;
 
 	if ((!is_local) && (is_register))	// Запрет на глобальные регистровые переменные
 	{

--- a/libs/compiler/mipsgen.c
+++ b/libs/compiler/mipsgen.c
@@ -3149,8 +3149,8 @@ static void emit_function_definition(encoder *const enc, const node *const nd)
 
 	uni_printf(enc->sx->io, "\n\t# function parameters:\n");
 
-	size_t gpr_count = 0;
-	size_t fp_count = 0;
+	size_t register_arguments_amount = 0;
+	size_t floating_register_arguments_amount = 0;
 
 	for (size_t i = 0; i < parameters; i++)
 	{
@@ -3159,11 +3159,11 @@ static void emit_function_definition(encoder *const enc, const node *const nd)
 
 		if (!type_is_floating(ident_get_type(enc->sx, id)))
 		{
-			if (gpr_count < ARG_REG_AMOUNT)
+			if (register_arguments_amount < ARG_REG_AMOUNT)
 			{
 				// Рассматриваем их как регистровые переменные
 				const item_t type = ident_get_type(enc->sx, id);
-				const mips_register_t curr_reg = R_A0 + gpr_count++;
+				const mips_register_t curr_reg = R_A0 + register_arguments_amount++;
 				uni_printf(enc->sx->io, "is in register ");
 				mips_register_to_io(enc->sx->io, curr_reg);
 				uni_printf(enc->sx->io, "\n");
@@ -3184,11 +3184,11 @@ static void emit_function_definition(encoder *const enc, const node *const nd)
 		}
 		else
 		{
-			if (fp_count < ARG_REG_AMOUNT / 2)
+			if (floating_register_arguments_amount < ARG_REG_AMOUNT / 2)
 			{
 				// Рассматриваем их как регистровые переменные
 				const item_t type = ident_get_type(enc->sx, id);
-				const mips_register_t curr_reg = R_FA0 + 2 * fp_count++;
+				const mips_register_t curr_reg = R_FA0 + 2 * floating_register_arguments_amount++;
 				uni_printf(enc->sx->io, "is in register ");
 				mips_register_to_io(enc->sx->io, curr_reg);
 				uni_printf(enc->sx->io, "\n");

--- a/libs/compiler/mipsgen.c
+++ b/libs/compiler/mipsgen.c
@@ -1114,7 +1114,7 @@ static lvalue displacements_add(encoder *const enc, const size_t identifier)
 		enc->scope_displ += mips_type_size(enc->sx, type);
 		enc->max_displ = max(enc->scope_displ, enc->max_displ);
 	}
-	const size_t location = is_local ? -enc->scope_displ : enc->global_displ;
+	const item_t location = is_local ? -(item_t)enc->scope_displ : enc->global_displ;
 
 	if ((!is_local) && (is_register))	// Запрет на глобальные регистровые переменные
 	{

--- a/libs/compiler/mipsgen.c
+++ b/libs/compiler/mipsgen.c
@@ -3174,10 +3174,12 @@ static void emit_function_definition(encoder *const enc, const node *const nd)
 			}
 			else
 			{
+				const item_t type = ident_get_type(enc->sx, id);
 				const size_t displ = i * WORD_LENGTH + FUNC_DISPL_PRESEREVED + WORD_LENGTH;
 				uni_printf(enc->sx->io, "is on stack at offset %zu from $fp\n", displ);
 
-				displacements_set(enc, id, displ, false);
+				const lvalue value = {.kind = LVALUE_KIND_STACK, .type = type, .loc.displ = displ, .base_reg = R_FP };
+				displacements_set(enc, id, &value);
 			}
 		}
 		else
@@ -3196,10 +3198,12 @@ static void emit_function_definition(encoder *const enc, const node *const nd)
 			}
 			else
 			{
+				const item_t type = ident_get_type(enc->sx, id);
 				const size_t displ = i * WORD_LENGTH + FUNC_DISPL_PRESEREVED + WORD_LENGTH;
 				uni_printf(enc->sx->io, "is on stack at offset %zu from $fp\n", displ);
 
-				displacements_set(enc, id, displ, false);
+				const lvalue value = {.kind = LVALUE_KIND_STACK, .type = type, .loc.displ = displ, .base_reg = R_FP };
+				displacements_set(enc, id, &value);
 			}
 		}
 	}


### PR DESCRIPTION
Для того, чтобы иметь возможность получать аргументы функции со стека, необходимо на момент объявления аргументов знать точный сдвиг $fp относительно значения $sp до вызова функции. Поскольку обработка тела функции (и, соответственно, вычисление размера статики) происходят после объявления аргументов, я решил изменить положение статики функции относительно $fp (как показано на изображениях ниже).
Я вижу только две альтернативы - объявлять аргументы после обработки тела (но тогда возникнут проблемы при использовании аргументов) или вычислять размер статики до объявления аргументов (что потребует двойной обход тела функции).
Как данные были расположены на стеке до изменений:
![old-stack-image](https://user-images.githubusercontent.com/50910468/218835251-996b438a-4eb4-4d13-a04f-a45a638f8eb2.png)
Как данные расположены на стеке после изменений:
![new-stack-image](https://user-images.githubusercontent.com/50910468/218838461-a8f8abb0-82e8-404f-91c9-171511664904.png)

Не PR, а драфт, потому что предполагает наличие изменений из #359, как изменения из него будут приняты, переделаю в полноценный PR