### PR TITLE
Const type modifier

### DIFF
--- a/.github/workflows/virtual.yml
+++ b/.github/workflows/virtual.yml
@@ -15,7 +15,7 @@ jobs:
           fetch-depth: 0
       - name: Run script
         shell: bash
-        run: ./scripts/test.sh -d
+        run: ./scripts/test.sh
 
   ubuntu:
     name: Ubuntu 20.04

--- a/.github/workflows/virtual.yml
+++ b/.github/workflows/virtual.yml
@@ -15,7 +15,7 @@ jobs:
           fetch-depth: 0
       - name: Run script
         shell: bash
-        run: ./scripts/test.sh
+        run: ./scripts/test.sh -d
 
   ubuntu:
     name: Ubuntu 20.04

--- a/libs/compiler/builder.c
+++ b/libs/compiler/builder.c
@@ -61,7 +61,7 @@ static item_t usual_arithmetic_conversions(const syntax *const sx, node *const L
 	const item_t LHS_type = expression_get_type(LHS);
 	const item_t RHS_type = expression_get_type(RHS);
 
-	if (type_is_floating(sx,LHS_type) || type_is_floating(sx,RHS_type))
+	if (type_is_floating(sx, LHS_type) || type_is_floating(sx, RHS_type))
 	{
 		*LHS = build_cast_expression(TYPE_FLOATING, LHS);
 		*RHS = build_cast_expression(TYPE_FLOATING, RHS);
@@ -437,7 +437,7 @@ builder builder_create(syntax *const sx)
 }
 
 
-bool check_assignment_operands(builder *const bldr, item_t expected_type, node *const init, const bool is_declaration)
+bool check_assignment_operands(builder *const bldr, const item_t expected_type, node *const init, const bool is_declaration)
 {
 	if (!node_is_correct(init))
 	{

--- a/libs/compiler/builder.c
+++ b/libs/compiler/builder.c
@@ -531,6 +531,45 @@ bool check_assignment_operands(builder *const bldr, item_t expected_type, node *
 		return true;
 	}
 
+	if (type_is_pointer(sx, expected_type) && type_is_pointer(sx, actual_type))
+	{
+		item_t expected_element_type = type_pointer_get_element_type(sx, expected_type);
+		const item_t actual_element_type = type_pointer_get_element_type(sx, actual_type);
+		if (type_has_const_modifier(sx, expected_element_type) && !type_has_const_modifier(sx, actual_element_type))
+		{
+			if (type_is_const(sx, expected_element_type))
+			{
+				expected_element_type = type_const_get_element_type(sx, expected_element_type);
+			}
+			else
+			{
+				switch (expected_element_type)
+				{
+					case TYPE_CONST_BOOLEAN:
+						expected_element_type = TYPE_BOOLEAN;
+						break;
+					case TYPE_CONST_CHARACTER:
+						expected_element_type = TYPE_CHARACTER;
+						break;
+					case TYPE_CONST_FILE:
+						expected_element_type = TYPE_FILE;
+						break;
+					case TYPE_CONST_FLOATING:
+						expected_element_type = TYPE_FLOATING;
+						break;
+					case TYPE_CONST_INTEGER:
+						expected_element_type = TYPE_INTEGER;
+						break;
+						// default:
+				}
+			}
+			if (expected_element_type == actual_element_type)
+			{
+				return true;
+			}
+		}
+	}
+
 	if (expected_type == actual_type)
 	{
 		return true;

--- a/libs/compiler/builder.c
+++ b/libs/compiler/builder.c
@@ -447,14 +447,15 @@ bool check_assignment_operands(builder *const bldr, const item_t expected_type, 
 	syntax *const sx = bldr->sx;
 	const location loc = node_get_location(init);
 
-	const item_t expected_type_unqualified = type_is_const(sx, expected_type) 
-		? type_const_get_unqualified_type(sx, expected_type)
-		: expected_type;
 	if (type_is_const(sx, expected_type) && !is_declaration)
 	{
 		semantic_error(bldr, loc, assign_to_const);
 		return false;
 	}
+
+	const item_t expected_type_unqualified = type_is_const(sx, expected_type) 
+		? type_const_get_unqualified_type(sx, expected_type)
+		: expected_type;
 
 	if (expression_get_class(init) == EXPR_INITIALIZER)
 	{
@@ -540,8 +541,7 @@ bool check_assignment_operands(builder *const bldr, const item_t expected_type, 
 			semantic_error(bldr, loc, invalid_const_pointer_cast);
 			return false;
 		}
-		if (type_is_const(sx, expected_element_type) && !type_is_const(sx, actual_element_type)
-			&& actual_element_type == type_const_get_unqualified_type(sx, expected_element_type))
+		if (type_is_const(sx, expected_element_type) && actual_element_type == type_const_get_unqualified_type(sx, expected_element_type))
 		{
 			return true;
 		}

--- a/libs/compiler/builder.h
+++ b/libs/compiler/builder.h
@@ -52,13 +52,14 @@ builder builder_create(syntax *const sx);
  *	Check assignment operands
  *	@note	TODO: Remove
  *
- *	@param	bldr			AST builder
- *	@param	expected_type	Expected type
- *	@param	init			Initializer
+ *	@param	bldr				AST builder
+ *	@param	expected_type		Expected type
+ *	@param	init				Initializer
+ *	@param	can_assign_to_const	@c 1 if allowed to assign to const type, @c 0 if not
  *
  *	@return	@c 1 on true, @c 0 on false
  */
-bool check_assignment_operands(builder *const bldr, const item_t expected_type, node *const init);
+bool check_assignment_operands(builder *const bldr, const item_t expected_type, node *const init, const bool can_assign_to_const);
 
 /**
  *	Build an identifier expression
@@ -278,13 +279,14 @@ node build_empty_bound_expression(builder *const bldr, const location loc);
  *	@param	type			Member type
  *	@param	name			Member name
  *	@param	was_star		Flag if there was a star token
+ *	@param	was_const		Flag if there was a const token after a star token
  *	@param	bounds			Member array bounds
  *	@param	loc				Member location
  *
  *	@return	Member declaration
  */
 node build_member_declaration(builder *const bldr, const item_t type, const size_t name, const bool was_star
-	, node_vector *const bounds, const location loc);
+	, const bool was_const, node_vector *const bounds, const location loc);
 
 /**
  *	Build an empty struct declaration
@@ -315,6 +317,7 @@ node build_struct_declaration(builder *const bldr, node *const declaration, node
  *	@param	type			Base type
  *	@param	name			Name
  *	@param	was_star		Flag if there was a star token
+ *	@param	was_const		Flag if there was a const token after a star token
  *	@param	bounds			Bounds expressions
  *	@param	initializer		Initializer
  *	@param	ident_loc		Identifier location
@@ -322,7 +325,7 @@ node build_struct_declaration(builder *const bldr, node *const declaration, node
  *	@return	Declarator
  */
 node build_declarator(builder *const bldr, const item_t type, const size_t name
-	, const bool was_star, node_vector *const bounds, node *const initializer, const location ident_loc);
+	, const bool was_star, const bool was_const, node_vector *const bounds, node *const initializer, const location ident_loc);
 
 /**
  *	Build an empty declaration

--- a/libs/compiler/codegen.c
+++ b/libs/compiler/codegen.c
@@ -355,6 +355,83 @@ static int print_table(const encoder *const enc, const vector *const table)
 }
 
 /**
+ *	Print types table unqualifying const types
+ *
+ *	@param	enc			Encoder
+ *
+ *	@return	@c 0 on success, @c -1 on error
+ */
+static int print_types_without_const(const encoder *const enc)
+{
+	const vector *const types = &enc->sx->types;
+
+	size_t start_type = enc->sx->start_type;
+	size_t next_type = vector_get(types, start_type);
+	while (next_type != 0)
+	{
+		start_type = next_type;
+		next_type = vector_get(types, start_type);
+	}
+
+	for (size_t i = 0; i < start_type; i++)
+	{
+		const item_t item = vector_get(types, i);
+		if (!item_check_var(enc->target, item))
+		{
+			system_error(tables_cannot_be_compressed);
+			return -1;
+		}
+
+		uni_printf(enc->sx->io, "%" PRIitem " ", item);
+	}
+
+	const size_t size = vector_size(types);
+	size_t index_shift = 0;
+	for (size_t i = start_type + 1; i < size;)
+	{
+		const type_t type = vector_get(types, i);
+		if (type == TYPE_CONST)
+		{
+			i += 3;
+			index_shift += 3;
+			continue;
+		}
+
+		size_t length = 1;
+		if (type == TYPE_STRUCTURE || type == TYPE_FUNCTION)
+		{
+			length = 2 + (size_t)vector_get(types, i + 2);
+		}
+
+		const item_t prev_type = vector_get(types, i - 1) - index_shift;
+		if (!item_check_var(enc->target, prev_type))
+		{
+			system_error(tables_cannot_be_compressed);
+			return -1;
+		}
+
+		uni_printf(enc->sx->io, "%" PRIitem " ", prev_type);
+
+		for (size_t j = i; j <= i + length; j++)
+		{
+			const item_t item = vector_get(types, j);
+			if (!item_check_var(enc->target, item))
+			{
+				system_error(tables_cannot_be_compressed);
+				return -1;
+			}
+
+			uni_printf(enc->sx->io, "%" PRIitem " ", item);
+		}
+
+		i += length + 2;
+	}
+
+	uni_printf(enc->sx->io, "\n");
+	return 0;
+}
+
+/**
  *	Export codes of virtual machine
  *
  *	@param	enc			Encoder
@@ -377,7 +454,7 @@ static int enc_export(const encoder *const enc)
 		|| print_table(enc, &enc->functions)
 		|| print_table(enc, &enc->identifiers)
 		|| print_table(enc, &enc->representations)
-		|| print_table(enc, &enc->sx->types);
+		|| print_types_without_const(enc);
 }
 
 /**
@@ -476,9 +553,10 @@ static lvalue emit_identifier_lvalue(encoder *const enc, const node *const nd)
 {
 	const size_t identifier = expression_identifier_get_id(nd);
 	const item_t type = ident_get_type(enc->sx, identifier);
+	const item_t unqualified_type =  type_is_const(enc->sx, type) ? type_const_get_unqualified_type(enc->sx, type) : type;
 	const item_t displ = displacements_get(enc, identifier);
 
-	return (lvalue){ .kind = VARIABLE, .type = type, .displ = displ };
+	return (lvalue){ .kind = VARIABLE, .type = unqualified_type, .displ = displ };
 }
 
 /**
@@ -579,6 +657,7 @@ static lvalue emit_member_lvalue(encoder *const enc, const node *const nd)
 static lvalue emit_indirection_lvalue(encoder *const enc, const node *const nd)
 {
 	const item_t type = expression_get_type(nd);
+	const item_t unqualified_type =  type_is_const(enc->sx, type) ? type_const_get_unqualified_type(enc->sx, type) : type;
 	const node operand = expression_unary_get_operand(nd);
 	const lvalue value = emit_lvalue(enc, &operand);
 	if (value.kind == VARIABLE)
@@ -587,7 +666,7 @@ static lvalue emit_indirection_lvalue(encoder *const enc, const node *const nd)
 		mem_add(enc, value.displ);
 	}
 
-	return (lvalue){ .kind = ADDRESS, .type = type };
+	return (lvalue){ .kind = ADDRESS, .type = unqualified_type };
 }
 
 /**
@@ -631,7 +710,9 @@ static lvalue emit_lvalue(encoder *const enc, const node *const nd)
  */
 static void emit_literal_expression(encoder *const enc, const node *const nd)
 {
-	switch (type_get_class(enc->sx, expression_get_type(nd)))
+	const item_t type = expression_get_type(nd);
+	const item_t unqualified_type =  type_is_const(enc->sx, type) ? type_const_get_unqualified_type(enc->sx, type) : type;
+	switch (type_get_class(enc->sx, unqualified_type))
 	{
 		case TYPE_NULL_POINTER:
 		{
@@ -770,8 +851,10 @@ static void compress_ident(encoder *const enc, const size_t ref)
 	}
 
 	const item_t new_ref = (item_t)vector_size(&enc->identifiers) - 1;
+	const item_t type = ident_get_type(enc->sx, ref);
+	const item_t unqualified_type =  type_is_const(enc->sx, type) ? type_const_get_unqualified_type(enc->sx, type) : type;
 	vector_add(&enc->identifiers, (item_t)vector_size(&enc->representations) - 2);
-	vector_add(&enc->identifiers, ident_get_type(enc->sx, ref));
+	vector_add(&enc->identifiers, unqualified_type);
 	vector_add(&enc->identifiers, displacements_get(enc, ref));
 
 	const char *buffer = repr_get_name(enc->sx, (size_t)ident_get_repr(enc->sx, ref));
@@ -862,7 +945,9 @@ static void emit_print_expression(encoder *const enc, const node *const nd)
 		emit_expression(enc, &arg);
 
 		mem_add(enc, IC_PRINT);
-		mem_add(enc, expression_get_type(&arg));
+		const item_t arg_type = expression_get_type(&arg);
+		const item_t unqualified_arg_type =  type_is_const(enc->sx, arg_type) ? type_const_get_unqualified_type(enc->sx, arg_type) : arg_type;
+		mem_add(enc, unqualified_arg_type);
 	}
 }
 
@@ -1381,6 +1466,11 @@ static void emit_array_declaration(encoder *const enc, const node *const nd)
 		dimensions++;
 	}
 
+	if (type_is_const(enc->sx, type))
+	{
+		type = type_const_get_unqualified_type(enc->sx, type);
+	}
+
 	const bool has_initializer = declaration_variable_has_initializer(nd);
 	const item_t length = (item_t)type_size(enc->sx, type);
 	const item_t displ = displacements_add(enc, identifier);
@@ -1435,7 +1525,8 @@ static void emit_variable_declaration(encoder *const enc, const node *const nd)
 	}
 
 	const item_t displ = displacements_add(enc, identifier);
-	const item_t iniproc = proc_get(enc, (size_t)type);
+	const item_t unqualified_type = type_is_const(enc->sx, type) ? type_const_get_unqualified_type(enc->sx, type) : type;
+	const item_t iniproc = proc_get(enc, (size_t)unqualified_type);
 	if (iniproc != ITEM_MAX && iniproc != 0)
 	{
 		mem_add(enc, IC_STRUCT_WITH_ARR);
@@ -1448,15 +1539,15 @@ static void emit_variable_declaration(encoder *const enc, const node *const nd)
 		const node initializer = declaration_variable_get_initializer(nd);
 		emit_expression(enc, &initializer);
 
-		if (type_is_structure(enc->sx, type))
+		if (type_is_structure(enc->sx, unqualified_type))
 		{
 			mem_add(enc, IC_COPY0ST_ASSIGN);
 			mem_add(enc, displ);
-			mem_add(enc, (item_t)type_size(enc->sx, type));
+			mem_add(enc, (item_t)type_size(enc->sx, unqualified_type));
 		}
 		else
 		{
-			mem_add(enc, type_is_floating(enc->sx, type) ? IC_ASSIGN_R_V : IC_ASSIGN_V);
+			mem_add(enc, type_is_floating(enc->sx, unqualified_type) ? IC_ASSIGN_R_V : IC_ASSIGN_V);
 			mem_add(enc, displ);
 		}
 	}

--- a/libs/compiler/codegen.c
+++ b/libs/compiler/codegen.c
@@ -440,7 +440,7 @@ static void emit_load_of_lvalue(encoder *const enc, lvalue value)
 			}
 			else
 			{
-				mem_add(enc, type_is_floating(value.type) ? IC_LOADD : IC_LOAD);
+				mem_add(enc, type_is_floating(enc->sx, value.type) ? IC_LOADD : IC_LOAD);
 				mem_add(enc, value.displ);
 			}
 
@@ -959,7 +959,7 @@ static void emit_cast_expression(encoder *const enc, const node *const nd)
 	const item_t source_type = expression_get_type(&subexpr);
 
 	// Необходимо только преобразование 'int' -> 'float'
-	if (type_is_integer(enc->sx, source_type) && type_is_floating(target_type))
+	if (type_is_integer(enc->sx, source_type) && type_is_floating(enc->sx, target_type))
 	{
 		mem_add(enc, IC_WIDEN);
 	}
@@ -984,7 +984,7 @@ static void emit_increment_expression(encoder *const enc, const node *const nd)
 		instruction = instruction_to_address_ver(instruction);
 	}
 
-	if (type_is_floating(expression_get_type(nd)))
+	if (type_is_floating(enc->sx, expression_get_type(nd)))
 	{
 		mem_add(enc, instruction_to_floating_ver(instruction));
 	}
@@ -1104,7 +1104,7 @@ static void emit_binary_expression(encoder *const enc, const node *const nd)
 		}
 
 		const instruction_t instruction = binary_to_instruction(operator);
-		if (type_is_floating(expression_get_type(&LHS)))
+		if (type_is_floating(enc->sx, expression_get_type(&LHS)))
 		{
 			mem_add(enc, instruction_to_floating_ver(instruction));
 		}
@@ -1180,7 +1180,7 @@ static void emit_assignment_expression(encoder *const enc, const node *const nd)
 			instruction = instruction_to_address_ver(instruction);
 		}
 
-		if (type_is_floating(type))
+		if (type_is_floating(enc->sx, type))
 		{
 			instruction = instruction_to_floating_ver(instruction);
 		}
@@ -1456,7 +1456,7 @@ static void emit_variable_declaration(encoder *const enc, const node *const nd)
 		}
 		else
 		{
-			mem_add(enc, type_is_floating(type) ? IC_ASSIGN_R_V : IC_ASSIGN_V);
+			mem_add(enc, type_is_floating(enc->sx, type) ? IC_ASSIGN_R_V : IC_ASSIGN_V);
 			mem_add(enc, displ);
 		}
 	}

--- a/libs/compiler/errors.c
+++ b/libs/compiler/errors.c
@@ -227,7 +227,7 @@ static void get_error(const err_t num, char *const msg, va_list args)
 			sprintf(msg, "нельзя присваивать значение константе");
 			break;
 		case invalid_const_pointer_cast:
-			sprintf(msg, "нельзя преобразовать указатель на коснтанту в указатель на переменную");
+			sprintf(msg, "нельзя преобразовать указатель на константу в указатель на переменную");
 			break;
 
 		// Builtin errors

--- a/libs/compiler/errors.c
+++ b/libs/compiler/errors.c
@@ -395,6 +395,15 @@ static void get_error(const err_t num, char *const msg, va_list args)
 		case not_decl:	// test_exist
 			sprintf(msg, "здесь должен быть тип (стандартный или описанный пользователем)");
 			break;
+		case multiple_const_in_type:
+			sprintf(msg, "встречено несколько модификаторов const для одного типа");
+			break;
+		case const_void:
+			sprintf(msg, "не существует типа const void");
+			break;
+		case assign_to_const:
+			sprintf(msg, "нельзя присваивать значение переменной с модификатором const");
+			break;
 		case empty_bound_without_init:	// test_exist
 			sprintf(msg, "в описании массива границы не указаны, а инициализации нет");
 			break;

--- a/libs/compiler/errors.c
+++ b/libs/compiler/errors.c
@@ -223,6 +223,12 @@ static void get_error(const err_t num, char *const msg, va_list args)
 		case nonvoid_func_void_return:
 			sprintf(msg, "функция должна возвращать значение");
 			break;
+		case assign_to_const:
+			sprintf(msg, "нельзя присваивать значение константе");
+			break;
+		case invalid_const_pointer_cast:
+			sprintf(msg, "нельзя преобразовать указатель на коснтанту в указатель на переменную");
+			break;
 
 		// Builtin errors
 		case too_many_printf_args:
@@ -397,12 +403,6 @@ static void get_error(const err_t num, char *const msg, va_list args)
 			break;
 		case multiple_const_in_type:
 			sprintf(msg, "встречено несколько модификаторов const для одного типа");
-			break;
-		case const_void:
-			sprintf(msg, "не существует типа const void");
-			break;
-		case assign_to_const:
-			sprintf(msg, "нельзя присваивать значение переменной с модификатором const");
 			break;
 		case empty_bound_without_init:	// test_exist
 			sprintf(msg, "в описании массива границы не указаны, а инициализации нет");

--- a/libs/compiler/errors.c
+++ b/libs/compiler/errors.c
@@ -229,6 +229,9 @@ static void get_error(const err_t num, char *const msg, va_list args)
 		case invalid_const_pointer_cast:
 			sprintf(msg, "нельзя преобразовать указатель на константу в указатель на переменную");
 			break;
+		case function_type_const:
+			sprintf(msg, "тип функции не может быть константой");
+			break;
 
 		// Builtin errors
 		case too_many_printf_args:

--- a/libs/compiler/errors.h
+++ b/libs/compiler/errors.h
@@ -96,6 +96,7 @@ typedef enum ERROR
 	assign_to_const,
 	invalid_const_pointer_cast,
 	function_type_const,
+	multiple_const_in_type,
 
 	// Builtin errors
 	too_many_printf_args,					/**< Too many printf arguments */
@@ -148,7 +149,6 @@ typedef enum ERROR
 	empty_init,
 	ident_not_type,
 	not_decl,
-	multiple_const_in_type,
 
 	empty_bound_without_init,
 

--- a/libs/compiler/errors.h
+++ b/libs/compiler/errors.h
@@ -93,6 +93,8 @@ typedef enum ERROR
 	main_should_be_defined,
 	wrong_main_parameters,
 	wrong_main_parameter_type,
+	assign_to_const,
+	invalid_const_pointer_cast,
 
 	// Builtin errors
 	too_many_printf_args,					/**< Too many printf arguments */
@@ -146,8 +148,6 @@ typedef enum ERROR
 	ident_not_type,
 	not_decl,
 	multiple_const_in_type,
-	const_void,
-	assign_to_const,
 
 	empty_bound_without_init,
 

--- a/libs/compiler/errors.h
+++ b/libs/compiler/errors.h
@@ -95,6 +95,7 @@ typedef enum ERROR
 	wrong_main_parameter_type,
 	assign_to_const,
 	invalid_const_pointer_cast,
+	function_type_const,
 
 	// Builtin errors
 	too_many_printf_args,					/**< Too many printf arguments */

--- a/libs/compiler/errors.h
+++ b/libs/compiler/errors.h
@@ -145,6 +145,9 @@ typedef enum ERROR
 	empty_init,
 	ident_not_type,
 	not_decl,
+	multiple_const_in_type,
+	const_void,
+	assign_to_const,
 
 	empty_bound_without_init,
 

--- a/libs/compiler/llvmgen.c
+++ b/libs/compiler/llvmgen.c
@@ -642,11 +642,11 @@ static void check_type_and_branch(information *const info, const item_t type)
 			{
 				to_code_unconditional_branch(info, info->answer_const ? info->label_true : info->label_false);
 			}
-			else if (type_is_boolean(type))
+			else if (type_is_boolean(info->sx, type))
 			{
 				to_code_unconditional_branch(info, info->answer_const_bool ? info->label_true : info->label_false);
 			}
-			else if (type_is_floating(type))
+			else if (type_is_floating(info->sx, type))
 			{
 				to_code_unconditional_branch(info, info->answer_const_double ? info->label_true : info->label_false);
 			}
@@ -658,11 +658,11 @@ static void check_type_and_branch(information *const info, const item_t type)
 			{
 				to_code_operation_reg_const_integer(info, BIN_NE, info->answer_reg, 0, TYPE_INTEGER);
 			}
-			else if (type_is_boolean(type))
+			else if (type_is_boolean(info->sx, type))
 			{
 				to_code_operation_reg_const_bool(info, BIN_NE, info->answer_reg, false, TYPE_BOOLEAN);
 			}
-			else if (type_is_floating(type))
+			else if (type_is_floating(info->sx, type))
 			{
 				to_code_operation_reg_const_double(info, BIN_NE, info->answer_reg, 0);
 			}
@@ -1043,7 +1043,7 @@ static void emit_call_expression(information *const info, const node *const nd)
 		{
 			arguments[i] = info->answer_const;
 		}
-		else if (type_is_boolean(arguments_value_type[i]))
+		else if (type_is_boolean(info->sx, arguments_value_type[i]))
 		{
 			arguments_bool[i] = info->answer_const_bool;
 		}
@@ -1151,7 +1151,7 @@ static void emit_call_expression(information *const info, const node *const nd)
 		{
 			uni_printf(info->sx->io, " %" PRIitem, arguments[i]);
 		}
-		else if (type_is_boolean(arguments_value_type[i]))
+		else if (type_is_boolean(info->sx, arguments_value_type[i]))
 		{
 			uni_printf(info->sx->io, " %s", arguments_bool[i] ? "true" : "false");
 		}
@@ -1334,7 +1334,7 @@ static void emit_unary_expression(information *const info, const node *const nd)
 			{
 				to_code_operation_reg_const_integer(info, BIN_XOR, info->answer_reg, -1, operation_type);
 			}
-			else if (operator == UN_MINUS && type_is_floating(operation_type))
+			else if (operator == UN_MINUS && type_is_floating(info->sx, operation_type))
 			{
 				to_code_operation_const_reg_double(info, BIN_SUB, 0, info->answer_reg);
 			}
@@ -1634,7 +1634,7 @@ static void emit_assignment_expression(information *const info, const node *cons
 			to_code_operation_reg_const_integer(info, assignment_type, info->register_num - 1
 				, info->answer_const, operation_type);
 		}
-		else if (type_is_floating(operation_type))
+		else if (type_is_floating(info->sx, operation_type))
 		{
 			to_code_operation_reg_const_double(info, assignment_type, info->register_num - 1
 				, info->answer_const_double);
@@ -1660,11 +1660,11 @@ static void emit_assignment_expression(information *const info, const node *cons
 	{
 		to_code_store_const_integer(info, info->answer_const, id, is_complex, !is_complex ? ident_is_local(info->sx, id) : true, operation_type);
 	}
-	else if (type_is_floating(operation_type))
+	else if (type_is_floating(info->sx, operation_type))
 	{
 		to_code_store_const_double(info, info->answer_const_double, id, is_complex, !is_complex ? ident_is_local(info->sx, id) : true);
 	}
-	else if (type_is_boolean(operation_type))
+	else if (type_is_boolean(info->sx, operation_type))
 	{
 		to_code_store_const_bool(info, info->answer_const_bool, id, is_complex, !is_complex ? ident_is_local(info->sx, id) : true);
 	}
@@ -2249,7 +2249,7 @@ static void emit_variable_declaration(information *const info, const node *const
 				{
 					to_code_store_const_integer(info, info->answer_const, info->request_reg, false, is_local, type);
 				}
-				else if (type_is_boolean(type))  
+				else if (type_is_boolean(info->sx, type))  
 				{
 					to_code_store_const_bool(info, info->answer_const_bool, info->request_reg, false, is_local);
 				}
@@ -2278,11 +2278,11 @@ static void emit_variable_declaration(information *const info, const node *const
 			{
 				to_code_store_const_integer(info, 0, id, false, is_local, type);
 			}
-			else if (type_is_boolean(type))  
+			else if (type_is_boolean(info->sx, type))  
 			{
 				to_code_store_const_bool(info, false, id, false, is_local);
 			}
-			else if (type_is_floating(type))  
+			else if (type_is_floating(info->sx, type))  
 			{
 				to_code_store_const_double(info, 0.0, id, false, is_local);
 			}
@@ -2330,11 +2330,11 @@ static void emit_variable_declaration(information *const info, const node *const
 			{
 				uni_printf(info->sx->io, " 0");
 			}
-			else if (type_is_floating(type))
+			else if (type_is_floating(info->sx, type))
 			{
 				uni_printf(info->sx->io, " 0.0");
 			}
-			else if (type_is_boolean(type))  
+			else if (type_is_boolean(info->sx, type))  
 			{
 				uni_printf(info->sx->io, " false");
 			}
@@ -2802,7 +2802,7 @@ static void emit_return_statement(information *const info, const node *const nd)
 		{
 			uni_printf(info->sx->io, " ret i32 %" PRIitem "\n", info->answer_const);
 		}
-		else if (info->answer_kind == ACONST && type_is_floating(answer_type))
+		else if (info->answer_kind == ACONST && type_is_floating(info->sx, answer_type))
 		{
 			uni_printf(info->sx->io, " ret double %f\n", info->answer_const_double);
 		}

--- a/libs/compiler/parser.c
+++ b/libs/compiler/parser.c
@@ -116,23 +116,6 @@ static void parser_error(parser *const prs, err_t num, ...)
 }
 
 /**
- *	Emit a syntax error from parser with specified location
- *
- *	@param	prs			Parser
- *	@param	num			Error code
- *	@param	loc			Location of error
- */
-static void parser_error_specified_loc(parser *const prs, err_t num, location loc, ...)
-{
-	va_list args;
-	va_start(args, loc);
-
-	report_error(&prs->sx->rprt, prs->sx->io, loc, num, args);
-
-	va_end(args);
-}
-
-/**
  *	Consume the current 'peek token' and lex the next one
  *
  *	@param	prs			Parser
@@ -835,7 +818,6 @@ static item_t parse_type_specifier(parser *const prs, const node *const parent)
 
 		case TK_CONST:
 		{
-			const location prev_loc = consume_token(prs);
 			const item_t type = parse_type_specifier(prs, parent);
 			switch(type)
 			{
@@ -845,7 +827,7 @@ static item_t parse_type_specifier(parser *const prs, const node *const parent)
 				{
 					if (type_is_const(prs->sx, type))
 					{
-						parser_error_specified_loc(prs, multiple_const_in_type, prev_loc);
+						parser_error(prs, multiple_const_in_type);
 						return TYPE_UNDEFINED;
 					}
 					return type_const(prs->sx, type);

--- a/libs/compiler/parser.c
+++ b/libs/compiler/parser.c
@@ -1891,6 +1891,10 @@ static item_t parse_function_declarator(parser *const prs, const int level, int 
 			{
 				arg_func = 1;
 				type = type_pointer(prs->sx, type);
+				if (try_consume_token(prs, TK_CONST))
+				{
+					type = type_const(prs->sx, type);
+				}
 			}
 
 			// На 1 уровне это может быть определением функции или предописанием;

--- a/libs/compiler/parser.c
+++ b/libs/compiler/parser.c
@@ -818,6 +818,7 @@ static item_t parse_type_specifier(parser *const prs, const node *const parent)
 
 		case TK_CONST:
 		{
+			consume_token(prs);
 			const item_t type = parse_type_specifier(prs, parent);
 			switch(type)
 			{

--- a/libs/compiler/parser.c
+++ b/libs/compiler/parser.c
@@ -782,8 +782,10 @@ static node parse_condition(parser *const prs)
 /**
  *	Parse type specifier
  *
- *	type-specifier:
+ *	type-qualifiers:
  *		`const`
+ *
+ *	type-specifier:
  *		`void`
  *		`bool`
  *		`char`
@@ -837,21 +839,6 @@ static item_t parse_type_specifier(parser *const prs, const node *const parent)
 			const item_t type = parse_type_specifier(prs, parent);
 			switch(type)
 			{
-				case TYPE_BOOLEAN:
-					return TYPE_CONST_BOOLEAN;			
-				case TYPE_CHARACTER:
-					return TYPE_CONST_CHARACTER;
-				case TYPE_INTEGER:
-					return TYPE_CONST_INTEGER;
-				case TYPE_FLOATING:
-					return TYPE_CONST_FLOATING;
-				case TYPE_FILE:
-					return TYPE_CONST_FILE;
-				case TYPE_VOID:
-				{
-					parser_error_specified_loc(prs, const_void, prev_loc);
-					return TYPE_UNDEFINED;
-				}
 				case TYPE_UNDEFINED:
 					return TYPE_UNDEFINED;
 				default:

--- a/libs/compiler/parser.c
+++ b/libs/compiler/parser.c
@@ -2112,6 +2112,11 @@ static void parse_function_definition(parser *const prs, node *const parent, con
  */
 static void parse_function_declaration(parser *const prs, node *const parent, const item_t type)
 {
+	if (type_is_const(prs->sx, type))
+	{
+		parser_error(prs, function_type_const);
+	}
+
 	const size_t function_num = func_reserve(prs->sx);
 	const size_t function_repr = token_get_ident_name(&prs->tk);
 

--- a/libs/compiler/parser.c
+++ b/libs/compiler/parser.c
@@ -906,7 +906,7 @@ static item_t parse_type_specifier(parser *const prs, const node *const parent)
  *	Parse member declaration
  *
  *	member-declaration:
- *		type-specifier member-declarator `;`
+ *		type-qualifiers type-specifier member-declarator `;`
  *
  *	member-declarator:
  *		`*`[opt] identifier
@@ -1252,7 +1252,7 @@ static node parse_init_declarator(parser *const prs, const item_t type)
  *	Parse declaration
  *
  *	declaration:
- *		type-specifier init-declarator-list[opt] `;`
+ *		type-qualifiers type-specifier init-declarator-list[opt] `;`
  *
  *	init-declarator-list:
  *		init-declarator

--- a/libs/compiler/syntax.c
+++ b/libs/compiler/syntax.c
@@ -562,7 +562,11 @@ type_t type_get_class(const syntax *const sx, const item_t type)
 
 size_t type_size(const syntax *const sx, const item_t type)
 {
-	if (type_is_structure(sx, type))
+	if (type_is_const(sx, type))
+	{
+		return type_size(sx, type_const_get_unqualified_type(sx, type));
+	}
+	else if (type_is_structure(sx, type))
 	{
 		return (size_t)type_get(sx, (size_t)type + 1);
 	}

--- a/libs/compiler/syntax.c
+++ b/libs/compiler/syntax.c
@@ -126,6 +126,11 @@ static inline bool type_is_equal(const syntax *const sx, const size_t first, con
 	size_t length = 1;
 	const item_t type = vector_get(&sx->types, first);
 
+	if (type == TYPE_CONST)
+	{
+		return type_is_equal(sx, type_const_get_unqualified_type(sx, first), type_const_get_unqualified_type(sx, second));
+	}
+
 	// Определяем, сколько полей надо сравнивать для различных типов записей
 	if (type == TYPE_STRUCTURE || type == TYPE_FUNCTION)
 	{

--- a/libs/compiler/syntax.c
+++ b/libs/compiler/syntax.c
@@ -566,7 +566,7 @@ size_t type_size(const syntax *const sx, const item_t type)
 	{
 		return (size_t)type_get(sx, (size_t)type + 1);
 	}
-	else if (type_is_floating(type))
+	else if (type_is_floating(sx, type))
 	{
 		return 2;
 	}
@@ -576,25 +576,26 @@ size_t type_size(const syntax *const sx, const item_t type)
 	}
 }
 
-bool type_is_boolean(const item_t type)
+bool type_is_boolean(const syntax *const sx, const item_t type)
 {
-	return type == TYPE_BOOLEAN || type == TYPE_CONST_BOOLEAN;
+	return type == TYPE_BOOLEAN || (type_is_const(sx, type) && type_is_boolean(sx, type_const_get_unqualified_type(sx, type)));
 }
 
 bool type_is_integer(const syntax *const sx, const item_t type)
 {
-	return type == TYPE_CHARACTER || type == TYPE_INTEGER || type == TYPE_CONST_CHARACTER ||
-		type == TYPE_CONST_INTEGER || type_is_enum(sx, type) || type_is_enum_field(sx, type);
+	return type_is_const(sx, type) 
+		? type_is_integer(sx, type_const_get_unqualified_type(sx, type)) 
+		:type == TYPE_CHARACTER || type == TYPE_INTEGER || type_is_enum(sx, type) || type_is_enum_field(sx, type);
 }
 
-bool type_is_floating(const item_t type)
+bool type_is_floating(const syntax *const sx, const item_t type)
 {
-	return type == TYPE_FLOATING || type == TYPE_CONST_FLOATING;
+	return type == TYPE_FLOATING || (type_is_const(sx, type) && type_is_floating(sx, type_const_get_unqualified_type(sx, type)));
 }
 
 bool type_is_arithmetic(const syntax *const sx, const item_t type)
 {
-	return type_is_integer(sx, type) || type_is_floating(type);
+	return type_is_integer(sx, type) || type_is_floating(sx, type);
 }
 
 bool type_is_void(const item_t type)
@@ -612,26 +613,21 @@ bool type_is_const(const syntax *const sx, const item_t type)
 	return type > 0 && type_get(sx, (size_t)type) == TYPE_CONST;
 }
 
-bool type_has_const_modifier(const syntax *const sx, const item_t type) {
-	return type_is_const(sx, type) || type == TYPE_CONST_FILE || type == TYPE_CONST_BOOLEAN ||
-		type == TYPE_CONST_FLOATING || type == TYPE_CONST_CHARACTER || type == TYPE_CONST_INTEGER;
-}
-
 bool type_is_array(const syntax *const sx, const item_t type)
 {
-	return type_is_const(sx, type) ? type_is_array(sx, type_const_get_element_type(sx, type))
+	return type_is_const(sx, type) ? type_is_array(sx, type_const_get_unqualified_type(sx, type))
 		: type > 0 && type_get(sx, (size_t)type) == TYPE_ARRAY;
 }
 
 bool type_is_structure(const syntax *const sx, const item_t type)
 {
-	return type_is_const(sx, type) ? type_is_structure(sx, type_const_get_element_type(sx, type))
+	return type_is_const(sx, type) ? type_is_structure(sx, type_const_get_unqualified_type(sx, type))
 		: type > 0 && type_get(sx, (size_t)type) == TYPE_STRUCTURE;
 }
 
 bool type_is_enum(const syntax *const sx, const item_t type)
 {
-	return type_is_const(sx, type) ? type_is_enum(sx, type_const_get_element_type(sx, type))
+	return type_is_const(sx, type) ? type_is_enum(sx, type_const_get_unqualified_type(sx, type))
 		: type > 0 && type_get(sx, (size_t)type) == TYPE_ENUM;
 }
 
@@ -647,13 +643,13 @@ bool type_is_function(const syntax *const sx, const item_t type)
 
 bool type_is_pointer(const syntax *const sx, const item_t type)
 {
-	return type_is_const(sx, type) ? type_is_pointer(sx, type_const_get_element_type(sx, type))
+	return type_is_const(sx, type) ? type_is_pointer(sx, type_const_get_unqualified_type(sx, type))
 		: type > 0 && type_get(sx, (size_t)type) == TYPE_POINTER;
 }
 
 bool type_is_scalar(const syntax *const sx, const item_t type)
 {
-	return type_is_boolean(type) || type_is_integer(sx, type) || type_is_pointer(sx, type) || type_is_null_pointer(type);
+	return type_is_boolean(sx, type) || type_is_integer(sx, type) || type_is_pointer(sx, type) || type_is_null_pointer(type);
 }
 
 bool type_is_aggregate(const syntax *const sx, const item_t type)
@@ -671,19 +667,19 @@ bool type_is_struct_pointer(const syntax *const sx, const item_t type)
 	return type_is_pointer(sx, type) && type_is_structure(sx, type_pointer_get_element_type(sx, type));
 }
 
-bool type_is_file(const item_t type)
+bool type_is_file(const syntax *const sx, const item_t type)
 {
-	return type == TYPE_FILE || type == TYPE_CONST_FILE;
+	return type == TYPE_FILE || (type_is_const(sx, type) && type_is_file(sx, type_const_get_unqualified_type(sx, type)));
 }
 
-item_t type_const_get_element_type(const syntax *const sx, const item_t type)
+item_t type_const_get_unqualified_type(const syntax *const sx, const item_t type)
 {
 	return type_is_const(sx, type) ? type_get(sx, (size_t)type + 1) : ITEM_MAX;
 }
 
 item_t type_array_get_element_type(const syntax *const sx, const item_t type)
 {
-	return type_is_const(sx, type) ? type_array_get_element_type(sx, type_const_get_element_type(sx, type))
+	return type_is_const(sx, type) ? type_array_get_element_type(sx, type_const_get_unqualified_type(sx, type))
 								   : type_is_array(sx, type) ? type_get(sx, (size_t)type + 1) : ITEM_MAX;
 }
 
@@ -713,19 +709,19 @@ item_t type_structure(syntax *const sx, vector *const types, vector *const names
 
 size_t type_structure_get_member_amount(const syntax *const sx, const item_t type)
 {
-	return type_is_const(sx, type) ? type_structure_get_member_amount(sx, type_const_get_element_type(sx, type))
+	return type_is_const(sx, type) ? type_structure_get_member_amount(sx, type_const_get_unqualified_type(sx, type))
 		: type_is_structure(sx, type) ? (size_t)type_get(sx, (size_t)type + 2) / 2 : SIZE_MAX;
 }
 
 size_t type_structure_get_member_name(const syntax *const sx, const item_t type, const size_t index)
 {
-	return type_is_const(sx, type) ? type_structure_get_member_name(sx, type_const_get_element_type(sx, type), index)
+	return type_is_const(sx, type) ? type_structure_get_member_name(sx, type_const_get_unqualified_type(sx, type), index)
 		: type_is_structure(sx, type) ? (size_t)type_get(sx, (size_t)type + 4 + 2 * index) : SIZE_MAX;
 }
 
 item_t type_structure_get_member_type(const syntax *const sx, const item_t type, const size_t index)
 {
-	return type_is_const(sx, type) ? type_structure_get_member_type(sx, type_const_get_element_type(sx, type), index)
+	return type_is_const(sx, type) ? type_structure_get_member_type(sx, type_const_get_unqualified_type(sx, type), index)
 		: type_is_structure(sx, type) ? type_get(sx, (size_t)type + 3 + 2 * index) : ITEM_MAX;
 }
 
@@ -747,7 +743,7 @@ item_t type_function_get_parameter_type(const syntax *const sx, const item_t typ
 
 item_t type_pointer_get_element_type(const syntax *const sx, const item_t type)
 {
-	return type_is_const(sx, type) ? type_pointer_get_element_type(sx, type_const_get_element_type(sx, type))
+	return type_is_const(sx, type) ? type_pointer_get_element_type(sx, type_const_get_unqualified_type(sx, type))
 		: type_is_pointer(sx, type) ? type_get(sx, (size_t)type + 1) : ITEM_MAX;
 }
 

--- a/libs/compiler/syntax.h
+++ b/libs/compiler/syntax.h
@@ -37,11 +37,6 @@ extern "C" {
 /** Type qualifiers */
 typedef enum TYPE
 {
-	TYPE_CONST_FILE			= -17,
-	TYPE_CONST_BOOLEAN		= -14,
-	TYPE_CONST_FLOATING,
-	TYPE_CONST_CHARACTER,
-	TYPE_CONST_INTEGER,
 	TYPE_VARARG			= -9,
 	TYPE_NULL_POINTER,
 	TYPE_FILE,
@@ -383,11 +378,12 @@ size_t type_size(const syntax *const sx, const item_t type);
 /**
  *	Check if type is boolean
  *
+ *	@param	sx			Syntax structure
  *	@param	type		Type for check
  *
  *	@return	@c 1 on true, @c 0 on false
  */
-bool type_is_boolean(const item_t type);
+bool type_is_boolean(const syntax *const sx, const item_t type);
 
 /**
  *	Check if type is integer
@@ -402,11 +398,12 @@ bool type_is_integer(const syntax *const sx, const item_t type);
 /**
  *	Check if type is floating
  *
+ *	@param	sx			Syntax structure
  *	@param	type		Type for check
  *
  *	@return	@c 1 on true, @c 0 on false
  */
-bool type_is_floating(const item_t type);
+bool type_is_floating(const syntax *const sx, const item_t type);
 
 /**
  *	Check if type is arithmetic
@@ -444,15 +441,6 @@ bool type_is_null_pointer(const item_t type);
  *	@return	@c 1 on true, @c 0 on false
  */
 bool type_is_const(const syntax *const sx, const item_t type);
-
-/**
- *	Check if type has const modifier
- *
- *	@param	type		Type for check
- *
- *	@return	@c 1 on true, @c 0 on false
- */
-bool type_has_const_modifier(const syntax *const sx, const item_t type);
 
 /**
  *	Check if type is array
@@ -566,11 +554,12 @@ bool type_is_undefined(const item_t type);
 /**
  *	Check if type is FILE
  *
+ *	@param	sx			Syntax structure
  *	@param	type		Type for check
  *
  *	@return	@c 1 on true, @c 0 on false
  */
-bool type_is_file(const item_t type);
+bool type_is_file(const syntax *const sx, const item_t type);
 
 /**
  *	Get element type
@@ -580,7 +569,7 @@ bool type_is_file(const item_t type);
  *
  *	@return	Element type, @c ITEM_MAX on failure
  */
-item_t type_const_get_element_type(const syntax *const sx, const item_t type);
+item_t type_const_get_unqualified_type(const syntax *const sx, const item_t type);
 
 /**
  *	Get element type

--- a/libs/compiler/syntax.h
+++ b/libs/compiler/syntax.h
@@ -37,6 +37,11 @@ extern "C" {
 /** Type qualifiers */
 typedef enum TYPE
 {
+	TYPE_CONST_FILE			= -17,
+	TYPE_CONST_BOOLEAN		= -14,
+	TYPE_CONST_FLOATING,
+	TYPE_CONST_CHARACTER,
+	TYPE_CONST_INTEGER,
 	TYPE_VARARG			= -9,
 	TYPE_NULL_POINTER,
 	TYPE_FILE,
@@ -53,6 +58,7 @@ typedef enum TYPE
 	TYPE_ARRAY,
 	TYPE_POINTER,
 	TYPE_ENUM,
+	TYPE_CONST,
 
 	BEGIN_USER_TYPE = 15,
 } type_t;
@@ -431,6 +437,24 @@ bool type_is_void(const item_t type);
 bool type_is_null_pointer(const item_t type);
 
 /**
+ *	Check if type is const type
+ *
+ *	@param	type		Type for check
+ *
+ *	@return	@c 1 on true, @c 0 on false
+ */
+bool type_is_const(const syntax *const sx, const item_t type);
+
+/**
+ *	Check if type has const modifier
+ *
+ *	@param	type		Type for check
+ *
+ *	@return	@c 1 on true, @c 0 on false
+ */
+bool type_has_const_modifier(const syntax *const sx, const item_t type);
+
+/**
  *	Check if type is array
  *
  *	@param	sx			Syntax structure
@@ -547,6 +571,16 @@ bool type_is_undefined(const item_t type);
  *	@return	@c 1 on true, @c 0 on false
  */
 bool type_is_file(const item_t type);
+
+/**
+ *	Get element type
+ *
+ *	@param	sx			Syntax structure
+ *	@param	type		Const type
+ *
+ *	@return	Element type, @c ITEM_MAX on failure
+ */
+item_t type_const_get_element_type(const syntax *const sx, const item_t type);
 
 /**
  *	Get element type
@@ -691,6 +725,16 @@ item_t type_function(syntax *const sx, const item_t return_type, const char *con
  *	@return	Pointer type
  */
 item_t type_pointer(syntax *const sx, const item_t type);
+
+/**
+ *	Create const type
+ *
+ *	@param	sx			Syntax structure
+ *	@param	type		Referenced type
+ *
+ *	@return	Const type
+ */
+item_t type_const(syntax *const sx, const item_t type);
 
 
 /**

--- a/libs/compiler/syntax.h
+++ b/libs/compiler/syntax.h
@@ -562,12 +562,12 @@ bool type_is_undefined(const item_t type);
 bool type_is_file(const syntax *const sx, const item_t type);
 
 /**
- *	Get element type
+ *	Get unqualified type
  *
  *	@param	sx			Syntax structure
  *	@param	type		Const type
  *
- *	@return	Element type, @c ITEM_MAX on failure
+ *	@return	Unqualified type, @c ITEM_MAX on failure
  */
 item_t type_const_get_unqualified_type(const syntax *const sx, const item_t type);
 

--- a/libs/compiler/token.h
+++ b/libs/compiler/token.h
@@ -37,6 +37,7 @@ typedef enum TOKEN
 	TK_BREAK,						/**< 'break' keyword */
 	TK_CASE,						/**< 'case' keyword */
 	TK_CHAR,						/**< 'char' keyword */
+	TK_CONST, 						/**< 'const' keyword */
 	TK_CONTINUE,					/**< 'continue' keyword */
 	TK_DEFAULT,						/**< 'default' keyword */
 	TK_DO,							/**< 'do' keyword */

--- a/libs/compiler/writer.c
+++ b/libs/compiler/writer.c
@@ -2100,20 +2100,35 @@ int write_type_spelling(const syntax *const sx, const item_t type, char *const b
 		case TYPE_FILE:
 			return sprintf(buffer, "FILE");
 
+		case TYPE_CONST_FILE:
+			return sprintf(buffer, "const FILE");
+
 		case TYPE_VOID:
 			return sprintf(buffer, "void");
 
 		case TYPE_BOOLEAN:
 			return sprintf(buffer, "bool");
+			
+		case TYPE_CONST_BOOLEAN:
+			return sprintf(buffer, "const bool");
 
 		case TYPE_FLOATING:
 			return sprintf(buffer, "double");
 
+		case TYPE_CONST_FLOATING:
+			return sprintf(buffer, "const float");
+
 		case TYPE_CHARACTER:
 			return sprintf(buffer, "char");
 
+		case TYPE_CONST_CHARACTER:
+			return sprintf(buffer, "const char");
+
 		case TYPE_INTEGER:
 			return sprintf(buffer, "int");
+			
+		case TYPE_CONST_INTEGER:
+			return sprintf(buffer, "const int");
 
 		case TYPE_UNDEFINED:
 			return sprintf(buffer, "undefined type");
@@ -2172,6 +2187,23 @@ int write_type_spelling(const syntax *const sx, const item_t type, char *const b
 			int index = write_type_spelling(sx, element_type, buffer);
 			index += sprintf(&buffer[index], "*");
 			return index;
+		}
+
+		case TYPE_CONST:
+		{
+			const item_t element_type = type_const_get_element_type(sx, type);
+			if (type_is_pointer(sx, element_type))
+			{
+				int index = write_type_spelling(sx, element_type, buffer);
+				index += sprintf(&buffer[index], " const");
+				return index;
+			}
+			else
+			{
+				int index = sprintf(buffer, "const ");
+				index += write_type_spelling(sx, element_type, &buffer[index]);
+				return index; 
+			}
 		}
 
 		default:

--- a/libs/compiler/writer.c
+++ b/libs/compiler/writer.c
@@ -2100,35 +2100,20 @@ int write_type_spelling(const syntax *const sx, const item_t type, char *const b
 		case TYPE_FILE:
 			return sprintf(buffer, "FILE");
 
-		case TYPE_CONST_FILE:
-			return sprintf(buffer, "const FILE");
-
 		case TYPE_VOID:
 			return sprintf(buffer, "void");
 
 		case TYPE_BOOLEAN:
 			return sprintf(buffer, "bool");
-			
-		case TYPE_CONST_BOOLEAN:
-			return sprintf(buffer, "const bool");
 
 		case TYPE_FLOATING:
 			return sprintf(buffer, "double");
 
-		case TYPE_CONST_FLOATING:
-			return sprintf(buffer, "const float");
-
 		case TYPE_CHARACTER:
 			return sprintf(buffer, "char");
 
-		case TYPE_CONST_CHARACTER:
-			return sprintf(buffer, "const char");
-
 		case TYPE_INTEGER:
 			return sprintf(buffer, "int");
-			
-		case TYPE_CONST_INTEGER:
-			return sprintf(buffer, "const int");
 
 		case TYPE_UNDEFINED:
 			return sprintf(buffer, "undefined type");
@@ -2191,7 +2176,7 @@ int write_type_spelling(const syntax *const sx, const item_t type, char *const b
 
 		case TYPE_CONST:
 		{
-			const item_t element_type = type_const_get_element_type(sx, type);
+			const item_t element_type = type_const_get_unqualified_type(sx, type);
 			if (type_is_pointer(sx, element_type))
 			{
 				int index = write_type_spelling(sx, element_type, buffer);

--- a/tests/semantics/assign_to_const.c
+++ b/tests/semantics/assign_to_const.c
@@ -1,0 +1,6 @@
+// Cannot assign to const
+void main()
+{
+    const int a = 5;
+    a = 6;
+}

--- a/tests/semantics/function_type_const.c
+++ b/tests/semantics/function_type_const.c
@@ -1,0 +1,9 @@
+const int f()
+{
+    return 0;
+}
+
+void main()
+{
+
+}

--- a/tests/semantics/invalid_const_pointer_cast.c
+++ b/tests/semantics/invalid_const_pointer_cast.c
@@ -1,0 +1,7 @@
+// Cannot make pointer to variable out of pointer to const
+void main()
+{
+    int a;
+    const int *b = &a;
+    int *c = b;
+}

--- a/tests/semantics/multiple_const_in_type.c
+++ b/tests/semantics/multiple_const_in_type.c
@@ -1,0 +1,4 @@
+void main()
+{
+    const const int a;
+}


### PR DESCRIPTION
Реализован модификатор `const`. Использование:
- Не больше одного модификатора только перед типом
- Не больше одного модификатора после звездочки, перед именем переменной